### PR TITLE
deterministic hugepage size, set without kexec

### DIFF
--- a/features/orabos/file.include/etc/kernel/cmdline.d/30-hugepages.cfg
+++ b/features/orabos/file.include/etc/kernel/cmdline.d/30-hugepages.cfg
@@ -1,0 +1,1 @@
+CMDLINE_LINUX="$CMDLINE_LINUX default_hugepagesz=1G"

--- a/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/ensure-hugepages.sh
+++ b/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/ensure-hugepages.sh
@@ -36,14 +36,19 @@ if [ $hugepages -le 0 ]; then
   exit 0
 fi
 
-cmdline="$(</proc/cmdline) hugepages=$hugepages"
-release=$(uname -r)
 
-NEWROOT=${NEWROOT:-/sysroot}
+echo $hugepages > /proc/sys/vm/nr_hugepages
+# might get more hugepages and faster with the kernel cmdline, but like this you avoid a kexec reboot.
 
-kexec \
-  -l $NEWROOT/boot/vmlinuz-${release} \
-  --initrd=$NEWROOT/boot/initrd.img-${release} \
-  --command-line="$cmdline"
 
-kexec -e --reset-vga
+#cmdline="$(</proc/cmdline) hugepages=$hugepages"
+#release=$(uname -r)
+
+#NEWROOT=${NEWROOT:-/sysroot}
+
+#kexec \
+#  -l $NEWROOT/boot/vmlinuz-${release} \
+#  --initrd=$NEWROOT/boot/initrd.img-${release} \
+#  --command-line="$cmdline"
+
+#kexec -e --reset-vga

--- a/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/module-setup.sh
+++ b/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/module-setup.sh
@@ -12,5 +12,5 @@ depends() {
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
 	inst_hook pre-pivot 00 "$moddir/ensure-hugepages.sh"
-	inst kexec
+	#inst kexec
 }


### PR DESCRIPTION
hugepaes have not been set deterministically, fixed by adding it to the kernel cmdline

added a direct application of hugepages to dracut -> no kexec needed anymore

has a slight delay but in initrd this still should be fast.
