### PR TITLE
fix: Add checksum to ignition package

### DIFF
--- a/features/metal3/exec.config
+++ b/features/metal3/exec.config
@@ -10,6 +10,7 @@ TEMP_DEB_DIR="$(mktemp -d)"
 package_name="ignition"
 repo="cobaltcore-dev/package-$package_name"
 tag="2.20.0-0gl0"
+checksum="e65f565eb298289ad9bacce40fe577845673fdf44d974758ef2ad5a7d4ade5a2"
 arch="$(dpkg --print-architecture)"
 
 urls=$(curl -s "https://api.github.com/repos/${repo}/releases/tags/$tag" | jq -r '.assets.[].browser_download_url' | grep "build.tar.xz")
@@ -18,6 +19,7 @@ for url in $urls; do
 done
 
 cat "$TEMP_DEB_DIR"/build.tar.xz* | xz -d | tar -C "$TEMP_DEB_DIR" -x
+echo "${checksum}" "$TEMP_DEB_DIR/${package_name}_${tag}_${arch}.deb" | sha256sum -c || exit 1
 DEBIAN_FRONTEND=noninteractive dpkg -i "$TEMP_DEB_DIR/${package_name}_${tag}_${arch}.deb"
 rm -rf "$TEMP_DEB_DIR"
 


### PR DESCRIPTION
This adds the sha256 checksum before installing the ignition package
from GitHub artifacts.
