### PR TITLE
fix: set gardener as dependency of metal3

### DIFF
--- a/features/metal3/info.yaml
+++ b/features/metal3/info.yaml
@@ -4,3 +4,4 @@ features:
   include:
     - _ignite
     - sssd
+    - gardener


### PR DESCRIPTION
this enables containerd as expected
