### PR TITLE
Remove config drive from repart.d

### DIFF
--- a/features/orabos/file.include/etc/repart.d/12_config_drive.conf
+++ b/features/orabos/file.include/etc/repart.d/12_config_drive.conf
@@ -1,7 +1,0 @@
-# This needs to stay as long as we use config-drives
-# It doesn't add much in case we don't.
-# As the time of writing metal3 and nova/ironic do.
-[Partition]
-Type=linux-generic
-Label=config-2
-SizeMaxBytes=64M


### PR DESCRIPTION
The removed file breaks with systemd 257 (vs 256). It claims there is not enough space for the config.
The file should be superfluous anyway, as undeclared partitions (such as EFI before and now config-2) should be simply left alone.
