### PR TITLE
Add systemd unit for reloading libvirtd tls certificates

### DIFF
--- a/features/orabos/file.include/etc/polkit-1/rules.d/00-kvm-node-agent.rules
+++ b/features/orabos/file.include/etc/polkit-1/rules.d/00-kvm-node-agent.rules
@@ -1,9 +1,11 @@
-// Allow kvm-node-agent to manage sysupgrade-sysupdate service units;
+// Allow kvm-node-agent to manage specific service units;
 // fall back to implicit authorization otherwise.
+
+const units = ["systemd-sysupdate", "libvirtd", "virt-admin"];
 polkit.addRule(function(action, subject) {
     if (action.id == "org.freedesktop.systemd1.manage-units" &&
     subject.user == "kvm-node-agent" &&
-    action.lookup("unit").startsWith("systemd-sysupdate")) {
+    units.filter(function (unit) { return action.lookup("unit").startsWith(unit) }).length ) {
         return polkit.Result.YES;
     }
 });

--- a/features/orabos/file.include/etc/systemd/system/virt-admin-server-update-tls.service
+++ b/features/orabos/file.include/etc/systemd/system/virt-admin-server-update-tls.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run virt-admin server-update-tls
+Documentation=man:virt-admin(1)
+Wants=libvirtd.service
+After=libvirtd.service
+ConditionVirtualization=!container
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/virt-admin server-update-tls --server libvirtd


### PR DESCRIPTION
Add systemd unit for reloading libvirtd tls certificates

**What this PR does / why we need it**:
This enables the kvm-node-agent to manage/install TLS certificates for libvirt.

