### PR TITLE
Set hugepages dynamically without kexec

### DIFF
--- a/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/ensure-hugepages.sh
+++ b/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/ensure-hugepages.sh
@@ -2,48 +2,32 @@
 # This file is part of dracut ensure-hugepages module.
 # SPDX-License-Identifier: MIT
 
-hugepages=$(getarg hugepages=) || hugepages=0
+hugepages=$(getarg hugepages=) || hugepages=-1	# -1 for unset
 
 mem_total_mb=$(($(sed -rn 's/MemTotal:\s+(.*) kB/\1/p' /proc/meminfo) / 1024 ))
 hugepagesize_mb=$(($(sed -rn 's/Hugepagesize:\s+(.*) kB/\1/p' /proc/meminfo) / 1024 ))
 
-function adopt_watermark_scale_factor() {
-  # On a 3TiB host, the default watermark_scale_factor=10 was exactly that
-  # that the kswapd0 was running permanently. Setting it to 5 was solving the
-  # issue, but is likely a suboptimal value, but a first start.
-  # The value 500 reproduces exactly that value for that scale, and hopefully
-  # also holds for larger hosts.
-  max_watermark_scale_factor=$(($non_hugepages_mb * 500 / $mem_total_mb))
-  watermark_scale_factor=$(</proc/sys/vm/watermark_scale_factor)
-  if [ $max_watermark_scale_factor -lt $watermark_scale_factor ]; then
-    echo $max_watermark_scale_factor > /proc/sys/vm/watermark_scale_factor
-  fi
-}
-
-if [ ${hugepages:-0} -gt 0 ]; then
-  hugepages_mb=$(($hugepages * $hugepagesize_mb))
-  non_hugepages_mb=$(($mem_total_mb - $hugepages_mb))
-  adopt_watermark_scale_factor
-  exit 0
+if [ $hugepages -lt 0 ]; then	# presumably unset, derive it from rdnon_hugepages or from default
+  non_hugepages_pm=$(getarg rd.non_hugepages_pm=) || non_hugepages_pm=45
+  non_hugepages_mb=$(( ($mem_total_mb * $non_hugepages_pm) / 1000 ))
+  hugepages=$(( ($mem_total_mb - $non_hugepages_mb ) / $hugepagesize_mb ))
 fi
 
 
-non_hugepages_pm=$(getarg rd.non_hugepages_pm=) || non_hugepages_pm=50
-non_hugepages_mb=$(( ($mem_total_mb * $non_hugepages_pm) / 1000 ))
-hugepages=$(( ($mem_total_mb - $non_hugepages_mb ) / $hugepagesize_mb ))
-
-if [ $hugepages -le 0 ]; then
+if [ ${hugepages:-0} -lt 0 ]; then
   exit 0
 fi
 
-cmdline="$(</proc/cmdline) hugepages=$hugepages"
-release=$(uname -r)
+# On a 3TiB host, the default watermark_scale_factor=10 was exactly that
+# that the kswapd0 was running permanently. Setting it to 5 was solving the
+# issue, but is likely a suboptimal value, but a first start.
+# The value 500 reproduces exactly that value for that scale, and hopefully
+# also holds for larger hosts.
+max_watermark_scale_factor=$(($non_hugepages_mb * 500 / $mem_total_mb))
+watermark_scale_factor=$(</proc/sys/vm/watermark_scale_factor)
+if [ $max_watermark_scale_factor -lt $watermark_scale_factor ]; then
+  echo $max_watermark_scale_factor > /proc/sys/vm/watermark_scale_factor
+fi
 
-NEWROOT=${NEWROOT:-/sysroot}
-
-kexec \
-  -l $NEWROOT/boot/vmlinuz-${release} \
-  --initrd=$NEWROOT/boot/initrd.img-${release} \
-  --command-line="$cmdline"
-
-kexec -e --reset-vga
+# Only after having set the above, we an actually reserve the hugepages
+echo $hugepages > /proc/sys/vm/nr_hugepages

--- a/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/module-setup.sh
+++ b/features/orabos/file.include/usr/lib/dracut/modules.d/99ensure-hugepages/module-setup.sh
@@ -11,6 +11,5 @@ depends() {
 
 # Install the required file(s) and directories for the module in the initramfs.
 install() {
-	inst_hook pre-pivot 00 "$moddir/ensure-hugepages.sh"
-	inst kexec
+	inst_hook cmdline 00 "$moddir/ensure-hugepages.sh"
 }


### PR DESCRIPTION
While kexec has the advantage of ensuring the hugepages as early as possible in the boot process, it comes with the downside of running in buggy firmware / driver interactions which do not handle a restart with kexec so well.
