### PR TITLE
feat: switch to latest gardenlinux to make use of os-release

### DIFF
--- a/features/orabos/exec.config
+++ b/features/orabos/exec.config
@@ -10,12 +10,6 @@ adduser --uid 476 openvswitch \
 
 adduser root openvswitch # Otherwise does not want to run as root:openvswitch
 
-# make os_release compliant to systemd spec
-cat >> /etc/os-release << EOF
-IMAGE_VERSION=${BUILDER_VERSION}
-VARIANT_ID=${BUILDER_CNAME%-*}
-EOF
-
 function create() {
   NAME=$1
   shift


### PR DESCRIPTION
IMAGE_VERSION and VARIANT_ID are now upsteam:
https://github.com/gardenlinux/gardenlinux/pull/2663
