### PR TITLE
[orabos] Disable orabos-init-network without netplan

### DIFF
--- a/features/orabos/file.include/etc/systemd/system/orabos-init-network.service
+++ b/features/orabos/file.include/etc/systemd/system/orabos-init-network.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Orabos Init Network
 DefaultDependencies=no
+ConditionFileIsExecutable=/usr/sbin/netplan
 Wants=ovsdb-server.service
 Wants=ovs-vswitchd.service
 After=ovsdb-server.service


### PR DESCRIPTION
The script only works with netplan anyway. We can remove it, as soon as we have migrated to metal-api.
