### PR TITLE
Update exec.config, symlink PKI paths for kvm-node-agent sync

### DIFF
--- a/features/orabos/exec.config
+++ b/features/orabos/exec.config
@@ -32,6 +32,8 @@ chsh -s /bin/bash nova
 mkdir -p /var/lib/nova/{.ssh,instances,mnt}
 chown -R nova:libvirt-qemu /var/lib/nova/{.ssh,instances,mnt}
 chmod 0600 /var/lib/nova/.ssh
+mkdir -p /etc/pki && ln -s /var/lib/kvm-node-agent/CA /etc/pki/CA
+ln -s /var/lib/kvm-node-agent/libvirt /etc/pki/libvirt
 
 # limit vnc port autorange to possible kubernetes nodeports
 sed -i 's/#remote_display_port_min = 5900/remote_display_port_min = 32200/' /etc/libvirt/qemu.conf

--- a/features/sci/exec.config
+++ b/features/sci/exec.config
@@ -32,6 +32,8 @@ chsh -s /bin/bash nova
 mkdir -p /var/lib/nova/{.ssh,instances,mnt}
 chown -R nova:libvirt-qemu /var/lib/nova/{.ssh,instances,mnt}
 chmod 0600 /var/lib/nova/.ssh
+mkdir -p /etc/pki && ln -s /var/lib/kvm-node-agent/CA /etc/pki/CA
+ln -s /var/lib/kvm-node-agent/libvirt /etc/pki/libvirt
 
 # limit vnc port autorange to possible kubernetes nodeports
 sed -i 's/#remote_display_port_min = 5900/remote_display_port_min = 32200/' /etc/libvirt/qemu.conf


### PR DESCRIPTION
The libvirt certificates will be managed by the unprivileged kvm-node-agent. (kvm-node-agent cannot write to /etc/pki due it's security settings)
