### PR TITLE
[metal3] consumer needs to decide on container runtime

### DIFF
--- a/features/metal3/exec.config
+++ b/features/metal3/exec.config
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuox pipefail
 
-# Undo the gardener feature disablement (for now)
-systemctl enable containerd
-
 TEMP_DEB_DIR="$(mktemp -d)"
 
 # gh release download --dir "$TEMP_DEB" --repo "$repo" "$tag"

--- a/features/metal3/info.yaml
+++ b/features/metal3/info.yaml
@@ -4,4 +4,3 @@ features:
   include:
     - _ignite
     - sssd
-    - gardener


### PR DESCRIPTION
* removed gardener dependency which just helped to sort the features
  correctly
* consumer must enable containerd or any other container runtime
