### PR TITLE
[sci] switch to pre-created libvirt pki directories

### DIFF
--- a/features/sci/exec.config
+++ b/features/sci/exec.config
@@ -32,8 +32,10 @@ chsh -s /bin/bash nova
 mkdir -p /var/lib/nova/{.ssh,instances,mnt}
 chown -R nova:libvirt-qemu /var/lib/nova/{.ssh,instances,mnt}
 chmod 0600 /var/lib/nova/.ssh
-mkdir -p /etc/pki && ln -s /var/lib/kvm-node-agent/CA /etc/pki/CA
-ln -s /var/lib/kvm-node-agent/libvirt /etc/pki/libvirt
+
+mkdir -p /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
+chown kvm-node-agent:kvm-node-agent /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
+chmod 0755 /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
 
 # limit vnc port autorange to possible kubernetes nodeports
 sed -i 's/#remote_display_port_min = 5900/remote_display_port_min = 32200/' /etc/libvirt/qemu.conf


### PR DESCRIPTION
Apparmor denies qemu to access certificates outside of the pki path
(e.g. via symlink), thus we change the strategy to directly mount the
pki directories into the kvm-node-agent. To mitigate a privileged
startup script, we need to pre-create and assign correct privileges to
the directories before mounting.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
