### PR TITLE
[sci] Lock down permissions on pki folders

### DIFF
--- a/features/sci/exec.config
+++ b/features/sci/exec.config
@@ -34,8 +34,8 @@ chown -R nova:libvirt-qemu /var/lib/nova/{.ssh,instances,mnt}
 chmod 0600 /var/lib/nova/.ssh
 
 mkdir -p /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
-chown kvm-node-agent:kvm-node-agent /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
-chmod 0755 /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
+chown kvm-node-agent:libvirt-qemu /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
+chmod 0750 /etc/pki/CA /etc/pki/libvirt /etc/pki/qemu
 
 # limit vnc port autorange to possible kubernetes nodeports
 sed -i 's/#remote_display_port_min = 5900/remote_display_port_min = 32200/' /etc/libvirt/qemu.conf


### PR DESCRIPTION
**What this PR does / why we need it**:

The permissions on the folder allow anyone to change into the directory, and potentially read the file.
It depends on the permissions of said file. By limiting the readers to the group libvirt-qemu, we lock the folder further down.
