### PR TITLE
bump gardenlinux workflows

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,6 +25,6 @@ jobs:
 
   build:
     needs: [set_version]
-    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@94b65dd96cd6a277d205829e03690005233524c0
+    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
     with:
       version: ${{ needs.set_version.outputs.VERSION }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,14 +19,14 @@ jobs:
           submodules: recursive
   build:
     needs: [checkout]
-    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@94b65dd96cd6a277d205829e03690005233524c0
+    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
     with:
       version: ${{ inputs.version || 'now' }}
   upload_oci:
     name: Run glcli to publish to OCI
     needs: [build]
     # use custom upload_oci.yml as we do not sign the images
-    # uses: gardenlinux/gardenlinux/.github/workflows/upload_oci.yml@94b65dd96cd6a277d205829e03690005233524c0
+    # uses: gardenlinux/gardenlinux/.github/workflows/upload_oci.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
     uses: ./.github/workflows/upload_oci.yml
     with:
       version: ${{ needs.build.outputs.version }}

--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -7,7 +7,7 @@ on:
         default: today
 jobs:
   generate_matrix_publish:
-    uses: gardenlinux/gardenlinux/.github/workflows/generate_matrix.yml@94b65dd96cd6a277d205829e03690005233524c0
+    uses: gardenlinux/gardenlinux/.github/workflows/generate_matrix.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
     with:
       flags: '--exclude "bare-*" --no-arch --json-by-arch --build --test'
   upload_gl_artifacts_to_oci:


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up of #57 to bump versions after https://github.com/gardenlinux/gardenlinux/pull/2889 was merged.