### PR TITLE
feat: add capi and _rescue features

### DIFF
--- a/features/_rescue/README.md
+++ b/features/_rescue/README.md
@@ -1,0 +1,10 @@
+## Feature: _rescue
+
+### Description
+
+<website-feature>
+Extra feature to allow rescue system to start
+</website-feature>
+
+### Features
+Extra feature to allow rescue system to start

--- a/features/_rescue/file.include/etc/dracut.conf.d/30-dracut-emergency.conf
+++ b/features/_rescue/file.include/etc/dracut.conf.d/30-dracut-emergency.conf
@@ -1,0 +1,2 @@
+add_dracutmodules+=" systemd-emergency "
+install_items+=" /etc/systemd/system/emergency.service.d/sulogin.conf " 

--- a/features/_rescue/file.include/etc/systemd/system/emergency.service.d/sulogin.conf
+++ b/features/_rescue/file.include/etc/systemd/system/emergency.service.d/sulogin.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=SYSTEMD_SULOGIN_FORCE=1

--- a/features/_rescue/info.yaml
+++ b/features/_rescue/info.yaml
@@ -1,0 +1,2 @@
+description: 'Rescue system'
+type: element

--- a/features/capi
+++ b/features/capi
@@ -1,1 +1,0 @@
-../gardenlinux/features/capi

--- a/features/capi/README.md
+++ b/features/capi/README.md
@@ -1,0 +1,11 @@
+## Feature: capi
+### Description
+<website-feature>
+This feature is supposed to just group a set of features used in IronCore and ConvergedCloud.
+This is supposed to be used only with the metal platform.
+</website-feature>
+
+### Features
+This is grouping a set of features needed when network bootstrapping servers in order to be used in a Kubernetes cluster.
+The only thing special about this feature is the replacement of ignition with ignition-legacy which is adding support for v2 ignition configs.
+This is required because only ignition v2 is supported when ignition is being used as the configuration engine for bootstrapping workload cluster machines with the Kubernetes cluster-api. 

--- a/features/capi/info.yaml
+++ b/features/capi/info.yaml
@@ -1,0 +1,11 @@
+description: 'cluster-api'
+type: element 
+features:
+  include:
+    - _pxe
+    - _rescue
+    - khost 
+    - server
+  exclude:
+    - _selinux
+    - firewall

--- a/features/capi/pkg.exclude
+++ b/features/capi/pkg.exclude
@@ -1,0 +1,1 @@
+ignition

--- a/features/capi/pkg.include
+++ b/features/capi/pkg.include
@@ -1,0 +1,2 @@
+ignition-legacy
+jq

--- a/features/sci/info.yaml
+++ b/features/sci/info.yaml
@@ -2,6 +2,7 @@ description: "SCI Baremetal OS"
 type: element
 features:
   include:
+    - _rescue
     - _slim
     - gardener
     - sssd

--- a/flavors.yaml
+++ b/flavors.yaml
@@ -38,3 +38,10 @@ targets:
         test: true
         test-platform: false
         publish: false
+      - features:
+          - capi
+        arch: amd64
+        build: true
+        test: true
+        test-platform: false
+        publish: false


### PR DESCRIPTION
* temporary disable old images
* move upstream capi feature locally and add https://github.com/gardenlinux/gardenlinux/pull/2894
* add rescue feature to for emergency shell access
