### PR TITLE
Temporarily disable nightlies

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,8 +1,8 @@
 name: nightly
 on:
-  schedule:
-    - cron: "0 6 * * *"
-  # triggered manually
+#  schedule:
+#    - cron: "0 6 * * *"
+#  # triggered manually
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Upstream added containerd 2.0. Until we can use it with Gardener we will
disable the nightlies. For now nightlies we need to trigger the build
manually using the 1850.0 version.