### PR TITLE
update python-gardenlinux-cli to 0.6.5

### DIFF
--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: "3.12"
       - name: Install glcli util
         run: |
-          git clone --depth 1 --branch 0.6.4 https://github.com/gardenlinux/python-gardenlinux-cli.git
+          git clone --depth 1 --branch 0.6.5 https://github.com/gardenlinux/python-gardenlinux-cli.git
           mv python-gardenlinux-cli /opt/glcli
           pip install -r /opt/glcli/requirements.txt
       - name: push using the glcli util


### PR DESCRIPTION
**What this PR does / why we need it**:
dependency adds initrd.unified - initrd containing the rootfs 

**Special notes for your reviewer**:
see release: https://github.com/gardenlinux/python-gardenlinux-cli/releases/tag/0.6.5