### PR TITLE
Allow overriding the hugepages memory permillage for UKI

### DIFF
--- a/features/_usi/initrd.include/usr/bin/persist
+++ b/features/_usi/initrd.include/usr/bin/persist
@@ -31,12 +31,13 @@ reboot-on-error 1
 EOF
 
 # START OF HUGE PAGES SETUP
+[ -f /sysroot/opt/persist/hugepages.env ] && . /sysroot/opt/persist/hugepages.env
 default_non_hugepages_pm=45  # this translates to 4.5%
+non_hugepages_pm="${NON_HUGEPAGES_PM:-$default_non_hugepages_pm}"
 
 mem_total_mb=$(($(sed -rn 's/MemTotal:\s+(.*) kB/\1/p' /proc/meminfo) / 1024 ))
 hugepagesize_mb=$(($(sed -rn 's/Hugepagesize:\s+(.*) kB/\1/p' /proc/meminfo) / 1024 ))
 
-non_hugepages_pm=$default_non_hugepages_pm
 non_hugepages_mb=$(( ($mem_total_mb * $non_hugepages_pm) / 1000 ))
 hugepages=$(( ($mem_total_mb - $non_hugepages_mb ) / $hugepagesize_mb ))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds the option to override the non-hugepages permillage using `/opt/persist/hugepages.env`. This is a preparatory step for a CI-ready USI: With hugepages enabled, the boot takes a **very** long time in a virtualized CI environment. Setting `NON_HUGEPAGES_PM` to 1000 effectively disables hugepages entirely.

**Note**:
I was tempted to use `/opt/persist/gl-oci.conf` since there does not seem to be any usage of the feature, but decided against it to not break any (non-public) setups.