### PR TITLE
Adding cloudhypervisor packages

### DIFF
--- a/features/sci/pkg.include
+++ b/features/sci/pkg.include
@@ -1,5 +1,8 @@
+cloud-hypervisor-gl
+conntrack
+edk2-cloud-hypervisor-gl
+libvirt-daemon-driver-ch-gl
 multipath-tools
 open-iscsi
 openvswitch-switch
-conntrack
 parted


### PR DESCRIPTION
This adds the following packages
* cloud-hypervisor-gl
* edk2-cloud-hypervisor-gl
* libvirt-daemon-driver-ch-gl

In addition, the pkg.include file got sorted properly.
