### PR TITLE
update gardenlinux submodule

### DIFF
--- a/.github/actions/setup
+++ b/.github/actions/setup
@@ -1,1 +1,0 @@
-../../gardenlinux/.github/actions/setup

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -25,6 +25,14 @@ jobs:
 
   build:
     needs: [set_version]
-    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
+    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
     with:
       version: ${{ needs.set_version.outputs.VERSION }}
+      # to set target to "prod" we need proper KMS secrets
+      target: dev
+      fail_fast: true
+    # secrets:
+      # aws_region: ${{ secrets.AWS_REGION }}
+      # aws_kms_role: ${{ secrets.KMS_SIGNING_IAM_ROLE }}
+      # aws_oidc_session: ${{ secrets.AWS_OIDC_SESSION }}
+      # secureboot_db_kms_arn: ${{ secrets.SECUREBOOT_DB_KMS_ARN }}

--- a/.github/workflows/github.mjs
+++ b/.github/workflows/github.mjs
@@ -1,0 +1,1 @@
+../../gardenlinux/.github/workflows/github.mjs

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,14 +19,22 @@ jobs:
           submodules: recursive
   build:
     needs: [checkout]
-    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
+    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
     with:
       version: ${{ inputs.version || 'now' }}
+      # to set target to "prod" we need proper KMS secrets
+      target: nightly
+      fail_fast: true
+    # secrets:
+      # aws_region: ${{ secrets.AWS_REGION }}
+      # aws_kms_role: ${{ secrets.KMS_SIGNING_IAM_ROLE }}
+      # aws_oidc_session: ${{ secrets.AWS_OIDC_SESSION }}
+      # secureboot_db_kms_arn: ${{ secrets.SECUREBOOT_DB_KMS_ARN }}
   upload_oci:
     name: Run glcli to publish to OCI
     needs: [build]
     # use custom upload_oci.yml as we do not sign the images
-    # uses: gardenlinux/gardenlinux/.github/workflows/upload_oci.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
+    # uses: gardenlinux/gardenlinux/.github/workflows/upload_oci.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
     uses: ./.github/workflows/upload_oci.yml
     with:
       version: ${{ needs.build.outputs.version }}

--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -7,7 +7,7 @@ on:
         default: today
 jobs:
   generate_matrix_publish:
-    uses: gardenlinux/gardenlinux/.github/workflows/generate_matrix.yml@3c22fe8b663d7a198f8dd99061db37c5ad8a8438
+    uses: gardenlinux/gardenlinux/.github/workflows/generate_matrix.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
     with:
       flags: '--exclude "bare-*" --no-arch --json-by-arch --build --test'
   upload_gl_artifacts_to_oci:

--- a/bare_flavors
+++ b/bare_flavors
@@ -1,0 +1,1 @@
+gardenlinux/bare_flavors

--- a/build_bare_flavors
+++ b/build_bare_flavors
@@ -1,0 +1,1 @@
+gardenlinux/build_bare_flavors

--- a/features/_usi/exec.post
+++ b/features/_usi/exec.post
@@ -6,7 +6,7 @@ rootfs="$1"
 
 mkdir -p "$rootfs/etc/gardenlinux"
 
-openssl x509 -in /builder/cert/gardenlinux-oci-sign.crt -pubkey -noout > "$rootfs/etc/gardenlinux/oci_signing_key.pem"
+openssl x509 -in /builder/cert/oci-sign.crt -pubkey -noout > "$rootfs/etc/gardenlinux/oci_signing_key.pem"
 for key in pk null.pk kek db; do
 	cp "/builder/cert/secureboot.$key.auth" "$rootfs/etc/gardenlinux/gardenlinux-secureboot.$key.auth"
 done

--- a/features/iscsi
+++ b/features/iscsi
@@ -1,0 +1,1 @@
+../gardenlinux/features/iscsi

--- a/features/lima
+++ b/features/lima
@@ -1,0 +1,1 @@
+../gardenlinux/features/lima

--- a/features/multipath
+++ b/features/multipath
@@ -1,0 +1,1 @@
+../gardenlinux/features/multipath

--- a/features/nvme
+++ b/features/nvme
@@ -1,0 +1,1 @@
+../gardenlinux/features/nvme

--- a/flavors.yaml
+++ b/flavors.yaml
@@ -33,6 +33,7 @@ targets:
         test: true
         test-platform: false
         publish: false
+  # this is needed as bare_flavors step in build.yml is currently hard wired
   - name: bare
     category: container
     flavors:

--- a/flavors.yaml
+++ b/flavors.yaml
@@ -33,3 +33,13 @@ targets:
         test: true
         test-platform: false
         publish: false
+  - name: bare
+    category: container
+    flavors:
+      - features:
+          - libc
+        arch: amd64
+        build: true
+        test: true
+        test-platform: false
+        publish: false

--- a/unbase_oci
+++ b/unbase_oci
@@ -1,0 +1,1 @@
+gardenlinux/unbase_oci


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the gardenlinux submodule. It includes several larger updates to the upstream build workflows. A `bare_flavor` has to be present in the `flavors.yml` as the code in `build.yml` is currently somewhat hard wired and needs at least a single bare flavor.
