### PR TITLE
do not build platform test images

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -22,16 +22,16 @@ jobs:
       - name: use VERSION file to support dev build on rel-branch
         id: version
         run: echo "VERSION=$(cat VERSION)" >> $GITHUB_OUTPUT
-
   build:
     needs: [set_version]
-    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
+    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@27b8bddd244614718c20cbf419d4025a57114e23
     with:
       version: ${{ needs.set_version.outputs.VERSION }}
       # to set target to "release" or "nightly" we need proper KMS secrets
       # have a look at gardenlinux/.github/workflows/github.mjs 
       target: dev
       fail_fast: true
+      platform_test_build: false
     # secrets:
       # aws_region: ${{ secrets.AWS_REGION }}
       # aws_kms_role: ${{ secrets.KMS_SIGNING_IAM_ROLE }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,7 +19,7 @@ jobs:
           submodules: recursive
   build:
     needs: [checkout]
-    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
+    uses: gardenlinux/gardenlinux/.github/workflows/build.yml@27b8bddd244614718c20cbf419d4025a57114e23
     with:
       version: ${{ inputs.version || 'now' }}
       # to set target to "release" or "nightly" we need proper KMS secrets
@@ -36,7 +36,7 @@ jobs:
     name: Run glcli to publish to OCI
     needs: [build]
     # use custom upload_oci.yml as we do not sign the images
-    # uses: gardenlinux/gardenlinux/.github/workflows/upload_oci.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
+    # uses: gardenlinux/gardenlinux/.github/workflows/upload_oci.yml@27b8bddd244614718c20cbf419d4025a57114e23
     uses: ./.github/workflows/upload_oci.yml
     with:
       version: ${{ needs.build.outputs.version }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -26,6 +26,7 @@ jobs:
       # have a look at gardenlinux/.github/workflows/github.mjs 
       target: dev
       fail_fast: true
+      platform_test_build: false
     # secrets:
       # aws_region: ${{ secrets.AWS_REGION }}
       # aws_kms_role: ${{ secrets.KMS_SIGNING_IAM_ROLE }}

--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   generate_matrix_publish:
     name: Generate flavors matrix to publish
-    uses: gardenlinux/gardenlinux/.github/workflows/build_flavors_matrix.yml@d9625e7e1dfbeb69952dd9efee7e7f21235f25c6
+    uses: gardenlinux/gardenlinux/.github/workflows/build_flavors_matrix.yml@27b8bddd244614718c20cbf419d4025a57114e23
     with:
       flags: '--exclude "bare-*" --no-arch --json-by-arch --build --test'
   upload_gl_artifacts_to_oci:


### PR DESCRIPTION
**What this PR does / why we need it**:

Do not build platform test images on gardelinux-ccloud.