### PR TITLE
CI: Add a Integration-style Test to Verify Basic HyperVisor Capabilities

### DIFF
--- a/.github/actions/test/integration/build/action.yml
+++ b/.github/actions/test/integration/build/action.yml
@@ -7,7 +7,8 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: set env
+    # TODO https://github.com/actions/cache
+    - name: Set ENV
       shell: bash
       env:
         REPO: ghcr.io/gardenlinux/gardenlinux-ccloud
@@ -19,6 +20,7 @@ runs:
         echo "TAG=$TAG" >> $GITHUB_ENV
         echo "ESP_SIZE=$ESP_SIZE" >> $GITHUB_ENV
         echo "DISK_SIZE=$DISK_SIZE" >> $GITHUB_ENV
+
     - name: Pull ORAS artifacts
       shell: bash
       run: |
@@ -28,10 +30,12 @@ runs:
 
         oras blob fetch "$REPO@$UKI_SHA" -o "$RUNNER_TEMP/$TAG.uki"
         oras blob fetch "$REPO@$TAR_SHA" -o "$RUNNER_TEMP/$TAG.tar" # wasteful, we only systemd-boot
+
     - name: Extract systemd-boot
       shell: bash
       run: |
         tar -xf "$RUNNER_TEMP/$TAG.tar" --no-same-owner --strip-components=5 -C "$RUNNER_TEMP" usr/lib/systemd/boot/efi/systemd-bootx64.efi
+
     - name: Set up a raw disk image
       shell: bash
       run: |
@@ -56,6 +60,7 @@ runs:
 
         sudo mkfs.vfat -F32 "$ESP_PART"
         sudo mkfs.ext4 "$VAR_PART" -L VAR
+
     - name: Populate the ESP partition
       shell: bash
       run: |
@@ -81,7 +86,40 @@ runs:
 
         sudo umount "$RUNNER_TEMP/esp"
         sudo losetup -d "$LOOPDEV"
+
     - name: Convert to QCOW2
       shell: bash
       run: |
-        qemu-img convert -O qcow2 "$DISK_IMG" "${RUNNER_TEMP}/${TAG}.qcow2"
+        qemu-img convert -O qcow2 "$DISK_IMG" "/opt/${TAG}.qcow2"
+
+    - name: Generate ignition
+      shell: bash
+      run: |
+        ssh-keygen -t ed25519 -f "ssh_host_ed25519_key" -N "" -C "user" -q
+        SSH_KEY=$(cat "ssh_host_ed25519_key.pub")
+        echo "SSH_KEY=$SSH_KEY" >> $GITHUB_ENV
+        sed -i "s|SSH_KEY_GOES_HERE|$SSH_KEY|g" ./.github/actions/test/integration/build/dev-user-butane.yaml
+        PASSWORD=$(openssl passwd "password")
+        echo "PASSWORD=$PASSWORD" >> $GITHUB_ENV
+        sed -i "s|PASSWORD_GOES_HERE|$PASSWORD|g" ./.github/actions/test/integration/build/dev-user-butane.yaml
+        butane --pretty --strict ./.github/actions/test/integration/build/dev-user-butane.yaml > "/opt/${TAG}.ign"
+
+    - name: Download ubuntu cloud image
+      shell: bash
+      run: |
+        wget -q "https://cloud-images.ubuntu.com/minimal/releases/noble/release/ubuntu-24.04-minimal-cloudimg-amd64.img" -O /opt/ubuntu.qcow2
+
+    - name: Generate ubuntu cloud-init
+      shell: bash
+      run: |
+        sed -i "s|SSH_KEY_GOES_HERE|$SSH_KEY|g" ./.github/actions/test/integration/build/user-data
+        sed -i "s|PASSWORD_GOES_HERE|$PASSWORD|g" ./.github/actions/test/integration/build/user-data
+        genisoimage -output /opt/ubuntu-cloud-init-ds.iso -volid cidata -joliet -rock ./.github/actions/test/integration/build/meta-data ./.github/actions/test/integration/build/user-data
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: gardenlinux-ccloud-${{ inputs.image_tag }}
+        path: /opt/${{ inputs.image_tag }}.*
+        retention-days: 1
+        overwrite: true

--- a/.github/actions/test/integration/build/action.yml
+++ b/.github/actions/test/integration/build/action.yml
@@ -81,7 +81,7 @@ runs:
         cat <<EOF | sudo tee "$RUNNER_TEMP/esp/loader/entries/gardenlinux.conf" > /dev/null
         title   Garden Linux (UKI)
         linux   /EFI/BOOT/gardenlinux.efi
-        options audit=0 console=ttyS0 ignition.firstboot=1 ignition.platform.id=qemu
+        options systemd.gpt_auto=0 audit=0 console=ttyS0 ignition.firstboot=1 ignition.platform.id=qemu
         EOF
 
         sudo umount "$RUNNER_TEMP/esp"
@@ -95,8 +95,9 @@ runs:
     - name: Generate ignition
       shell: bash
       run: |
-        ssh-keygen -t ed25519 -f "ssh_host_ed25519_key" -N "" -C "user" -q
-        SSH_KEY=$(cat "ssh_host_ed25519_key.pub")
+        ssh-keygen -t ed25519 -f "/opt/ssh_host_ed25519_key" -N "" -C "user" -q
+        chmod 600 /opt/ssh_host_ed25519_key
+        SSH_KEY=$(cat /opt/ssh_host_ed25519_key.pub)
         echo "SSH_KEY=$SSH_KEY" >> $GITHUB_ENV
         sed -i "s|SSH_KEY_GOES_HERE|$SSH_KEY|g" ./.github/actions/test/integration/build/dev-user-butane.yaml
         PASSWORD=$(openssl passwd "password")
@@ -116,10 +117,10 @@ runs:
         sed -i "s|PASSWORD_GOES_HERE|$PASSWORD|g" ./.github/actions/test/integration/build/user-data
         genisoimage -output /opt/ubuntu-cloud-init-ds.iso -volid cidata -joliet -rock ./.github/actions/test/integration/build/meta-data ./.github/actions/test/integration/build/user-data
 
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: gardenlinux-ccloud-${{ inputs.image_tag }}
-        path: /opt/${{ inputs.image_tag }}.*
-        retention-days: 1
-        overwrite: true
+    # - name: Upload artifacts
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: gardenlinux-ccloud-${{ inputs.image_tag }}
+    #     path: /opt/${{ inputs.image_tag }}.*
+    #     retention-days: 1
+    #     overwrite: true

--- a/.github/actions/test/integration/build/action.yml
+++ b/.github/actions/test/integration/build/action.yml
@@ -1,0 +1,87 @@
+name: build
+description: Build Bootable Virtual Machine Image
+inputs:
+  image_tag:
+    description: "Image tag to use for the build"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: set env
+      shell: bash
+      env:
+        REPO: ghcr.io/gardenlinux/gardenlinux-ccloud
+        TAG: ${{ inputs.image_tag }}
+        ESP_SIZE: 4 # GiB
+        DISK_SIZE: 8 # GiB
+      run: |
+        echo "REPO=$REPO" >> $GITHUB_ENV
+        echo "TAG=$TAG" >> $GITHUB_ENV
+        echo "ESP_SIZE=$ESP_SIZE" >> $GITHUB_ENV
+        echo "DISK_SIZE=$DISK_SIZE" >> $GITHUB_ENV
+    - name: Pull ORAS artifacts
+      shell: bash
+      run: |
+        LAYERS=$(oras manifest fetch "$REPO:$TAG" | jq -r '.layers[]')
+        UKI_SHA=$(echo $LAYERS | jq -r 'select(.mediaType=="application/io.gardenlinux.uki") | .digest')
+        TAR_SHA=$(echo "$LAYERS" | jq -r 'select(.mediaType=="application/io.gardenlinux.image.archive.format.tar")' | jq -rs 'sort_by(.size) | .[0].digest')
+
+        oras blob fetch "$REPO@$UKI_SHA" -o "$RUNNER_TEMP/$TAG.uki"
+        oras blob fetch "$REPO@$TAR_SHA" -o "$RUNNER_TEMP/$TAG.tar" # wasteful, we only systemd-boot
+    - name: Extract systemd-boot
+      shell: bash
+      run: |
+        tar -xf "$RUNNER_TEMP/$TAG.tar" --no-same-owner --strip-components=5 -C "$RUNNER_TEMP" usr/lib/systemd/boot/efi/systemd-bootx64.efi
+    - name: Set up a raw disk image
+      shell: bash
+      run: |
+        ESP_END="${ESP_SIZE}GiB"
+        DISK_IMG="${RUNNER_TEMP}/${TAG}.img"
+        echo "DISK_IMG=$DISK_IMG" >> $GITHUB_ENV
+
+        qemu-img create "$DISK_IMG" "${DISK_SIZE}G"
+        parted "$DISK_IMG" --script mklabel gpt
+        parted "$DISK_IMG" --script mkpart ESP fat32 1MiB "$ESP_END"
+        parted "$DISK_IMG" --script set 1 esp on
+        parted "$DISK_IMG" --script mkpart var ext4 "$ESP_END" 100%
+
+        parted "$DISK_IMG" --script name 1 ESP
+        parted "$DISK_IMG" --script name 2 VAR
+
+        LOOPDEV=$(sudo losetup --show -fP "$DISK_IMG")
+        echo "LOOPDEV=$LOOPDEV" >> $GITHUB_ENV
+        ESP_PART="${LOOPDEV}p1"
+        echo "ESP_PART=$ESP_PART" >> $GITHUB_ENV
+        VAR_PART="${LOOPDEV}p2"
+
+        sudo mkfs.vfat -F32 "$ESP_PART"
+        sudo mkfs.ext4 "$VAR_PART" -L VAR
+    - name: Populate the ESP partition
+      shell: bash
+      run: |
+        mkdir -p "$RUNNER_TEMP/esp"
+        sudo mount "$ESP_PART" "$RUNNER_TEMP/esp"
+
+        sudo mkdir -p "$RUNNER_TEMP/esp/EFI/BOOT"
+        sudo cp "$RUNNER_TEMP/systemd-bootx64.efi" "$RUNNER_TEMP/esp/EFI/BOOT/BOOTX64.EFI"
+        sudo cp "$RUNNER_TEMP/$TAG.uki" "$RUNNER_TEMP/esp/EFI/BOOT/gardenlinux.efi"
+
+        sudo mkdir -p "$RUNNER_TEMP/esp/loader/entries"
+
+        cat <<EOF | sudo tee "$RUNNER_TEMP/esp/loader/loader.conf" > /dev/null
+        default      gardenlinux
+        timeout      3
+        console-mode max
+        EOF
+        cat <<EOF | sudo tee "$RUNNER_TEMP/esp/loader/entries/gardenlinux.conf" > /dev/null
+        title   Garden Linux (UKI)
+        linux   /EFI/BOOT/gardenlinux.efi
+        options audit=0 console=ttyS0 ignition.firstboot=1 ignition.platform.id=qemu
+        EOF
+
+        sudo umount "$RUNNER_TEMP/esp"
+        sudo losetup -d "$LOOPDEV"
+    - name: Convert to QCOW2
+      shell: bash
+      run: |
+        qemu-img convert -O qcow2 "$DISK_IMG" "${RUNNER_TEMP}/${TAG}.qcow2"

--- a/.github/actions/test/integration/build/dev-user-butane.yaml
+++ b/.github/actions/test/integration/build/dev-user-butane.yaml
@@ -1,0 +1,52 @@
+variant: fcos
+version: 1.3.0
+passwd:
+  users:
+    - name: root
+      password_hash: "PASSWORD_GOES_HERE"
+storage:
+  files:
+  - path: /etc/ssh/sshd_config
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: |
+        PermitRootLogin yes
+        AuthorizedKeysFile /etc/ssh/authorized_keys
+        Protocol 2
+        AuthenticationMethods publickey password
+        Subsystem sftp /usr/lib/openssh/sftp-server
+  # can't store in /root, is a tmpfs
+  - path: /etc/ssh/authorized_keys
+    mode: 0600
+    contents:
+      inline: "SSH_KEY_GOES_HERE"
+  - path: /etc/hosts
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: |
+        # defaults
+        127.0.0.1	localhost
+        127.0.1.1	garden
+
+        ::1     localhost ip6-localhost ip6-loopback
+        ff02::1 ip6-allnodes
+        ff02::2 ip6-allrouters
+
+        # custom
+        192.168.122.2 hv1
+        192.168.122.3 hv2
+  - path: /opt/persist/root-hints.yaml
+    mode: 0644
+    contents:
+      inline: |
+        hints:
+          - size: lt 500G
+  # turn off hugepages, not required for this test
+  # also SIGNIFICANTLY reduces test runtime
+  - path: /opt/persist/hugepages.env
+    mode: 0755
+    contents:
+      inline: |
+        NON_HUGEPAGES_PM=1000

--- a/.github/actions/test/integration/build/dev-user-butane.yaml
+++ b/.github/actions/test/integration/build/dev-user-butane.yaml
@@ -50,3 +50,9 @@ storage:
     contents:
       inline: |
         NON_HUGEPAGES_PM=1000
+  # pull the image from GHCR instead of keppel
+  - path: /opt/persist/gl-oci.conf
+    mode: 0644
+    contents:
+      inline: |
+        OCI_REPO=ghcr.io/gardenlinux/gardenlinux-ccloud

--- a/.github/actions/test/integration/build/meta-data
+++ b/.github/actions/test/integration/build/meta-data
@@ -1,0 +1,2 @@
+instance-id: test-instance
+local-hostname: VM

--- a/.github/actions/test/integration/build/user-data
+++ b/.github/actions/test/integration/build/user-data
@@ -1,0 +1,18 @@
+#cloud-config
+users:
+  - name: root
+    shell: /bin/bash
+    ssh_authorized_keys:
+      - "SSH_KEY_GOES_HERE"
+    hashed_passwd: "PASSWORD_GOES_HERE"
+
+disable_root: false
+
+network:
+  version: 2
+  ethernets:
+    all-interfaces:
+      match:
+        name: "*"
+      dhcp4: true
+      dhcp6: true

--- a/.github/actions/test/integration/dependencies/action.yml
+++ b/.github/actions/test/integration/dependencies/action.yml
@@ -17,6 +17,13 @@ runs:
           virtinst \
           bridge-utils \
           ovmf
+    # Required for storing the ignition file in /var/lib/libvirt/images
+    - name: Disable libvirt qemu security driver
+      shell: bash
+      run: |
+        sudo sed -i '/^[#[:space:]]*security_driver[[:space:]]*=/d' /etc/libvirt/qemu.conf
+        echo 'security_driver = "none"' | sudo tee -a /etc/libvirt/qemu.conf
+        sudo systemctl restart libvirtd
     - name: oras
       uses: oras-project/setup-oras@v1
       with:

--- a/.github/actions/test/integration/dependencies/action.yml
+++ b/.github/actions/test/integration/dependencies/action.yml
@@ -17,6 +17,7 @@ runs:
           virtinst \
           bridge-utils \
           ovmf
+
     # Required for storing the ignition file in /var/lib/libvirt/images
     - name: Disable libvirt qemu security driver
       shell: bash
@@ -24,10 +25,12 @@ runs:
         sudo sed -i '/^[#[:space:]]*security_driver[[:space:]]*=/d' /etc/libvirt/qemu.conf
         echo 'security_driver = "none"' | sudo tee -a /etc/libvirt/qemu.conf
         sudo systemctl restart libvirtd
+
     - name: oras
       uses: oras-project/setup-oras@v1
       with:
         version: 1.2.2
+
     - name: butane
       shell: bash
       run: |

--- a/.github/actions/test/integration/dependencies/action.yml
+++ b/.github/actions/test/integration/dependencies/action.yml
@@ -8,7 +8,15 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install -y \
-          parted squashfs-tools qemu-kvm libvirt-daemon-system libvirt-clients virtinst bridge-utils ovmf
+          parted \
+          squashfs-tools \
+          qemu-kvm \
+          genisoimage \
+          libvirt-daemon-system \
+          libvirt-clients \
+          virtinst \
+          bridge-utils \
+          ovmf
     - name: oras
       uses: oras-project/setup-oras@v1
       with:
@@ -17,6 +25,6 @@ runs:
       shell: bash
       run: |
         BUTANE_VERSION="0.24.0"
-        curl -LO "https://github.com/coreos/butane/releases/download/v${BUTANE_VERSION}/butane-${BUTANE_VERSION}-linux-amd64"
-        chmod +x "butane-${BUTANE_VERSION}-linux-amd64"
-        sudo mv "butane-${BUTANE_VERSION}-linux-amd64" /usr/local/bin/butane
+        curl -LO "https://github.com/coreos/butane/releases/download/v${BUTANE_VERSION}/butane-x86_64-unknown-linux-gnu"
+        chmod +x "butane-x86_64-unknown-linux-gnu"
+        sudo mv "butane-x86_64-unknown-linux-gnu" /usr/local/bin/butane

--- a/.github/actions/test/integration/dependencies/action.yml
+++ b/.github/actions/test/integration/dependencies/action.yml
@@ -1,0 +1,22 @@
+name: dependencies
+description: Install Dependencies for Integration Test
+runs:
+  using: "composite"
+  steps:
+    - name: apt
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y \
+          parted squashfs-tools qemu-kvm libvirt-daemon-system libvirt-clients virtinst bridge-utils ovmf
+    - name: oras
+      uses: oras-project/setup-oras@v1
+      with:
+        version: 1.2.2
+    - name: butane
+      shell: bash
+      run: |
+        BUTANE_VERSION="0.24.0"
+        curl -LO "https://github.com/coreos/butane/releases/download/v${BUTANE_VERSION}/butane-${BUTANE_VERSION}-linux-amd64"
+        chmod +x "butane-${BUTANE_VERSION}-linux-amd64"
+        sudo mv "butane-${BUTANE_VERSION}-linux-amd64" /usr/local/bin/butane

--- a/.github/actions/test/integration/setup/action.yml
+++ b/.github/actions/test/integration/setup/action.yml
@@ -1,0 +1,124 @@
+name: setup
+description: Set up Hypervisor and VM Environment for Integration Tests
+runs:
+  using: "composite"
+  steps:
+    - name: Configure the default libvirt network
+      shell: bash
+      run: |
+        sudo virsh net-destroy default
+        sudo virsh net-undefine default
+        sudo virsh net-define ./.github/actions/test/integration/setup/virbr-hv.xml
+        sudo virsh net-start default
+        sudo virsh net-autostart default
+    - name: Copy ignition file
+      shell: bash
+      run: |
+        sudo cp "/opt/${TAG}.ign" /var/lib/libvirt/images/hv.ign
+    - name: Create HyperVisor 1
+      shell: bash
+      run: |
+        cp ./.github/actions/test/integration/setup/hv.xml ./.github/actions/test/integration/setup/hv1.xml
+        sed -i "s|HV_NAME_GOES_HERE|HV1|g" ./.github/actions/test/integration/setup/hv1.xml
+        sed -i "s|MAC_GOES_HERE|52:54:00:12:34:56|g" ./.github/actions/test/integration/setup/hv1.xml
+        sudo cp "/opt/${TAG}.qcow2" /var/lib/libvirt/images/HV1.qcow2
+
+        sudo virsh define ./.github/actions/test/integration/setup/hv1.xml
+        sudo virsh start HV1
+    - name: Create HyperVisor 2
+      shell: bash
+      run: |
+        cp ./.github/actions/test/integration/setup/hv.xml ./.github/actions/test/integration/setup/hv2.xml
+        sed -i "s|HV_NAME_GOES_HERE|HV2|g" ./.github/actions/test/integration/setup/hv2.xml
+        sed -i "s|MAC_GOES_HERE|52:54:00:65:43:21|g" ./.github/actions/test/integration/setup/hv2.xml
+        sudo cp "/opt/${TAG}.qcow2" /var/lib/libvirt/images/HV2.qcow2
+
+        sudo virsh define ./.github/actions/test/integration/setup/hv2.xml
+        sudo virsh start HV2
+    - name: Wait for HyperVisors to be ready
+      shell: bash
+      run: |
+        KEY=/opt/ssh_host_ed25519_key
+        SSH_OPTS="-i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+        USER="root"
+        MAX_ITER=30
+
+        wait_for_ssh() {
+          local VM_NAME="$1"
+
+          for ((i=1; i<=MAX_ITER; i++)); do
+            local MAC=$(sudo virsh domiflist "$VM_NAME" | awk '/network/ {print $5}')
+            local IP=$(sudo virsh net-dhcp-leases default | grep "$MAC" | sort --reverse | head -n 1 | awk '{print $5}' | cut -d'/' -f1)
+            if [ -n "$IP" ] && ssh $SSH_OPTS "$USER@$IP" 'exit' 2>/dev/null; then
+              echo "$VM_NAME is up at IP: $IP"
+              scp $SSH_OPTS ./.github/actions/test/integration/setup/virbr-vm.xml "$USER@$IP:/opt/virbr-vm.xml"
+              scp $SSH_OPTS /opt/ssh_host_ed25519_key "$USER@$IP:/opt/ssh_host_ed25519_key"
+              return 0
+            fi
+            if (( i == MAX_ITER )); then
+              echo "Timeout waiting for $VM_NAME to respond to SSH."
+              sudo cat "/var/log/$VM_NAME.log"
+              exit 1
+            fi
+            echo "Waiting for $VM_NAME to respond to SSH... ($i/$MAX_ITER)"
+            sleep 10
+          done
+        }
+
+        wait_for_ssh HV1
+        wait_for_ssh HV2
+    - name: Configure SSH between HyperVisors
+      uses: appleboy/ssh-action@v1
+      with:
+        host: "192.168.122.2,192.168.122.3"
+        username: root
+        key_path: /opt/ssh_host_ed25519_key
+        script: |
+          # Enable passwordless SSH between HyperVisors
+          chmod 700 /root/.ssh
+          echo "" > /root/.ssh/config
+          echo "Host 192.168.122.*" >> /root/.ssh/config
+          echo "    StrictHostKeyChecking no" >> /root/.ssh/config
+          echo "    UserKnownHostsFile /dev/null" >> /root/.ssh/config
+          echo "    IdentityFile /opt/ssh_host_ed25519_key" >> /root/.ssh/config
+          echo "    IdentitiesOnly yes" >> /root/.ssh/config
+          echo "    User root" >> /root/.ssh/config
+          chmod 600 /root/.ssh/config
+          chmod 600 /opt/ssh_host_ed25519_key
+    - name: Set up network and storage configuration on HyperVisors
+      uses: appleboy/ssh-action@v1
+      with:
+        host: "192.168.122.2,192.168.122.3"
+        username: root
+        key_path: /opt/ssh_host_ed25519_key
+        script: |
+          # Startup is somewhat flaky at the first nesting layer, so wait explicitly
+          systemctl start libvirtd
+          MAX_ITER=30
+          for ((i=1; i<=MAX_ITER; i++)); do
+            if systemctl is-active --quiet libvirtd; then
+              echo "libvirt is ready."
+              break
+            fi
+            if (( i == MAX_ITER )); then
+              echo "Timeout waiting for libvirt to be ready."
+              systemctl status libvirtd
+              journalctl -u libvirtd --no-pager
+              exit 1
+            fi
+            echo "Waiting for libvirt to be ready... ($i/$MAX_ITER)"
+            sleep 10
+          done
+
+          virsh pool-destroy default || true
+          virsh pool-undefine default || true
+          virsh pool-define-as default dir --target /var/lib/libvirt/images
+          virsh pool-build default
+          virsh pool-start default
+          virsh pool-autostart default
+
+          virsh net-destroy default || true
+          virsh net-undefine default || true
+          virsh net-define /opt/virbr-vm.xml
+          virsh net-start default
+          virsh net-autostart default

--- a/.github/actions/test/integration/setup/action.yml
+++ b/.github/actions/test/integration/setup/action.yml
@@ -11,10 +11,12 @@ runs:
         sudo virsh net-define ./.github/actions/test/integration/setup/virbr-hv.xml
         sudo virsh net-start default
         sudo virsh net-autostart default
+
     - name: Copy ignition file
       shell: bash
       run: |
         sudo cp "/opt/${TAG}.ign" /var/lib/libvirt/images/hv.ign
+
     - name: Create HyperVisor 1
       shell: bash
       run: |
@@ -25,6 +27,7 @@ runs:
 
         sudo virsh define ./.github/actions/test/integration/setup/hv1.xml
         sudo virsh start HV1
+
     - name: Create HyperVisor 2
       shell: bash
       run: |
@@ -35,6 +38,7 @@ runs:
 
         sudo virsh define ./.github/actions/test/integration/setup/hv2.xml
         sudo virsh start HV2
+
     - name: Wait for HyperVisors to be ready
       shell: bash
       run: |
@@ -47,13 +51,14 @@ runs:
           local VM_NAME="$1"
 
           for ((i=1; i<=MAX_ITER; i++)); do
-            local MAC=$(sudo virsh domiflist "$VM_NAME" | awk '/network/ {print $5}')
-            local IP=$(sudo virsh net-dhcp-leases default | grep "$MAC" | sort --reverse | head -n 1 | awk '{print $5}' | cut -d'/' -f1)
-            if [ -n "$IP" ] && ssh $SSH_OPTS "$USER@$IP" 'exit' 2>/dev/null; then
+            local IP=$(sudo virsh domifaddr "$VM_NAME" | awk '/ipv4/ {print $4}' | cut -d'/' -f1)
+            if [ -z "$IP" ]; then
+              echo "No IP address found for $VM_NAME. Retrying..."
+            elif ssh $SSH_OPTS "$USER@$IP" 'exit' 2>/dev/null; then
               echo "$VM_NAME is up at IP: $IP"
               scp $SSH_OPTS ./.github/actions/test/integration/setup/virbr-vm.xml "$USER@$IP:/opt/virbr-vm.xml"
               scp $SSH_OPTS /opt/ssh_host_ed25519_key "$USER@$IP:/opt/ssh_host_ed25519_key"
-              return 0
+              break
             fi
             if (( i == MAX_ITER )); then
               echo "Timeout waiting for $VM_NAME to respond to SSH."
@@ -67,6 +72,7 @@ runs:
 
         wait_for_ssh HV1
         wait_for_ssh HV2
+
     - name: Configure SSH between HyperVisors
       uses: appleboy/ssh-action@v1
       with:
@@ -74,7 +80,6 @@ runs:
         username: root
         key_path: /opt/ssh_host_ed25519_key
         script: |
-          # Enable passwordless SSH between HyperVisors
           chmod 700 /root/.ssh
           echo "" > /root/.ssh/config
           echo "Host 192.168.122.*" >> /root/.ssh/config
@@ -85,6 +90,7 @@ runs:
           echo "    User root" >> /root/.ssh/config
           chmod 600 /root/.ssh/config
           chmod 600 /opt/ssh_host_ed25519_key
+
     - name: Set up network and storage configuration on HyperVisors
       uses: appleboy/ssh-action@v1
       with:
@@ -92,23 +98,7 @@ runs:
         username: root
         key_path: /opt/ssh_host_ed25519_key
         script: |
-          # Startup is somewhat flaky at the first nesting layer, so wait explicitly
           systemctl start libvirtd
-          MAX_ITER=30
-          for ((i=1; i<=MAX_ITER; i++)); do
-            if systemctl is-active --quiet libvirtd; then
-              echo "libvirt is ready."
-              break
-            fi
-            if (( i == MAX_ITER )); then
-              echo "Timeout waiting for libvirt to be ready."
-              systemctl status libvirtd
-              journalctl -u libvirtd --no-pager
-              exit 1
-            fi
-            echo "Waiting for libvirt to be ready... ($i/$MAX_ITER)"
-            sleep 10
-          done
 
           virsh pool-destroy default || true
           virsh pool-undefine default || true

--- a/.github/actions/test/integration/setup/hv.xml
+++ b/.github/actions/test/integration/setup/hv.xml
@@ -1,0 +1,37 @@
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+    <name>HV_NAME_GOES_HERE</name>
+    <memory unit='GiB'>6</memory>
+    <vcpu placement='static'>4</vcpu>
+    <os firmware='efi'>
+        <type arch='x86_64'>hvm</type>
+        <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
+        <boot dev='hd' />
+    </os>
+    <features>
+        <acpi />
+    </features>
+    <cpu mode='host-passthrough' check='none' migratable='on' />
+    <devices>
+        <disk type='file' device='disk'>
+            <driver name='qemu' type='qcow2' />
+            <source file='/var/lib/libvirt/images/HV_NAME_GOES_HERE.qcow2' />
+            <target dev='hda' bus='ide' />
+        </disk>
+        <interface type='network'>
+            <mac address='MAC_GOES_HERE' />
+            <source network='default' />
+            <model type='virtio' />
+        </interface>
+        <console type='pty'>
+            <target type='serial' port='0' />
+        </console>
+        <serial type='file'>
+            <source path='/var/log/HV_NAME_GOES_HERE.log'/>
+            <target port='0'/>
+        </serial>
+    </devices>
+    <qemu:commandline>
+        <qemu:arg value='-fw_cfg' />
+        <qemu:arg value='name=opt/com.coreos/config,file=/var/lib/libvirt/images/hv.ign' />
+    </qemu:commandline>
+</domain>

--- a/.github/actions/test/integration/setup/virbr-hv.xml
+++ b/.github/actions/test/integration/setup/virbr-hv.xml
@@ -6,7 +6,6 @@
         </nat>
     </forward>
     <bridge name='virbr0' stp='on' delay='0' />
-    <mac address='52:54:00:aa:aa:aa' />
     <ip address='192.168.122.1' netmask='255.255.255.0'>
         <dhcp>
             <range start='192.168.122.100' end='192.168.122.254' />

--- a/.github/actions/test/integration/setup/virbr-hv.xml
+++ b/.github/actions/test/integration/setup/virbr-hv.xml
@@ -1,0 +1,17 @@
+<network>
+    <name>default</name>
+    <forward mode='nat'>
+        <nat>
+            <port start='1024' end='65535' />
+        </nat>
+    </forward>
+    <bridge name='virbr0' stp='on' delay='0' />
+    <mac address='52:54:00:aa:aa:aa' />
+    <ip address='192.168.122.1' netmask='255.255.255.0'>
+        <dhcp>
+            <range start='192.168.122.100' end='192.168.122.254' />
+            <host mac='52:54:00:12:34:56' ip='192.168.122.2' name='hv1' />
+            <host mac='52:54:00:65:43:21' ip='192.168.122.3' name='hv2' />
+        </dhcp>
+    </ip>
+</network>

--- a/.github/actions/test/integration/setup/virbr-vm.xml
+++ b/.github/actions/test/integration/setup/virbr-vm.xml
@@ -1,0 +1,15 @@
+<network>
+    <name>default</name>
+    <forward mode='nat'>
+        <nat>
+            <port start='1024' end='65535' />
+        </nat>
+    </forward>
+    <bridge name='virbr0' stp='on' delay='0' />
+    <mac address='52:54:00:bb:bb:bb' />
+    <ip address='192.168.222.1' netmask='255.255.255.0'>
+        <dhcp>
+            <range start='192.168.222.100' end='192.168.222.254' />
+        </dhcp>
+    </ip>
+</network>

--- a/.github/actions/test/integration/setup/virbr-vm.xml
+++ b/.github/actions/test/integration/setup/virbr-vm.xml
@@ -6,10 +6,10 @@
         </nat>
     </forward>
     <bridge name='virbr0' stp='on' delay='0' />
-    <mac address='52:54:00:bb:bb:bb' />
     <ip address='192.168.222.1' netmask='255.255.255.0'>
         <dhcp>
             <range start='192.168.222.100' end='192.168.222.254' />
+            <host mac='52:54:00:00:00:01' ip='192.168.222.2' name='vm' />
         </dhcp>
     </ip>
 </network>

--- a/.github/actions/test/integration/test/action.yml
+++ b/.github/actions/test/integration/test/action.yml
@@ -1,0 +1,6 @@
+name: test
+description: Execute Integration Tests for Hypervisor Capabilities
+runs:
+  using: "composite"
+  steps:
+    - name: Configure the default libvirt network

--- a/.github/actions/test/integration/test/action.yml
+++ b/.github/actions/test/integration/test/action.yml
@@ -3,4 +3,119 @@ description: Execute Integration Tests for Hypervisor Capabilities
 runs:
   using: "composite"
   steps:
-    - name: Configure the default libvirt network
+    - name: Copy VM defintions and artifacts to the HyperVisors
+      shell: bash
+      run: |
+        KEY=/opt/ssh_host_ed25519_key
+        SSH_OPTS="-i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+        USER="root"
+        IP_HV1="192.168.122.2"
+        IP_HV2="192.168.122.3"
+
+        scp $SSH_OPTS ./.github/actions/test/integration/test/vm.xml "$USER@$IP_HV1:/opt/vm.xml"
+        scp $SSH_OPTS /opt/ubuntu.qcow2 "$USER@$IP_HV1:/var/lib/libvirt/images/ubuntu.qcow2"
+        scp $SSH_OPTS /opt/ubuntu-cloud-init-ds.iso "$USER@$IP_HV1:/var/lib/libvirt/images/ubuntu-cloud-init-ds.iso"
+
+        # the cloud-init data is not migrated from source to destination, but needed for the VM to run at the destination
+        scp $SSH_OPTS /opt/ubuntu-cloud-init-ds.iso "$USER@$IP_HV2:/var/lib/libvirt/images/ubuntu-cloud-init-ds.iso"
+
+    - name: Start VM on HyperVisor 1
+      uses: appleboy/ssh-action@v1
+      with:
+        host: 192.168.122.2
+        username: root
+        key_path: /opt/ssh_host_ed25519_key
+        script: |
+          virsh define /opt/vm.xml
+          virsh start VM
+
+    - name: Wait for VM to be ready
+      uses: appleboy/ssh-action@v1
+      with:
+        host: 192.168.122.2
+        username: root
+        key_path: /opt/ssh_host_ed25519_key
+        script: |
+          KEY=/opt/ssh_host_ed25519_key
+          SSH_OPTS="-i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+          USER="root"
+
+          MAX_ITER=40
+          for ((i=1; i<=MAX_ITER; i++)); do
+            IP=$(virsh domifaddr VM | awk '/ipv4/ {print $4}' | cut -d'/' -f1)
+            if [ -z "$IP" ]; then
+              echo "No IP address found for VM. Retrying..."
+            elif ssh $SSH_OPTS "$USER@$IP" 'exit' 2>/dev/null; then
+              echo "VM is up at IP: $IP"
+              # create a dummy file for verification later
+              ssh $SSH_OPTS "$USER@$IP" 'echo "Hello, World!" > /opt/hello.txt'
+              break
+            fi
+            if (( i == MAX_ITER )); then
+              echo "Timeout waiting for VM to respond to SSH."
+              cat /var/log/VM.log
+              exit 1
+            fi
+            echo "Waiting for VM to respond to SSH... ($i/$MAX_ITER)"
+            sleep 10
+          done
+
+    - name: Mirgrate the VM to HyperVisor 2
+      uses: appleboy/ssh-action@v1
+      with:
+        host: 192.168.122.2
+        username: root
+        key_path: /opt/ssh_host_ed25519_key
+        script: |
+          USER="root"
+          HV2_IP="192.168.122.3"
+
+          virsh migrate --persistent --undefinesource --copy-storage-all --live VM qemu+ssh://$USER@$HV2_IP/system
+          if virsh dominfo VM &>/dev/null; then
+            echo "VM is still present on HV1 after migration!"
+            exit 1
+          fi
+
+    - name: Verify VM status on HyperVisor 2
+      uses: appleboy/ssh-action@v1
+      with:
+        host: 192.168.122.3
+        username: root
+        key_path: /opt/ssh_host_ed25519_key
+        command_timeout: 30m
+        script: |
+          if virsh dominfo VM | awk '/State:/ {print $2}' | grep -q "running"; then
+            echo "VM is running on HV2."
+          else
+            echo "VM is not running on HV2."
+            exit 1
+          fi
+
+          KEY=/opt/ssh_host_ed25519_key
+          SSH_OPTS="-i $KEY -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+          USER="root"
+          # waiting for the IP to be visible to the new HyperVisor via DHCP takes WAYYYYYYY too long
+          # the IP is static, so we can just use it directly
+          IP="192.168.222.2"
+
+          MAX_ITER=40
+          for ((i=1; i<=MAX_ITER; i++)); do
+            if ssh $SSH_OPTS "$USER@$IP" 'exit' 2>/dev/null; then
+              echo "VM is up at IP: $IP"
+              # verify the migration by checking the dummy file
+              if ssh $SSH_OPTS "$USER@$IP" 'test -f /opt/hello.txt'; then
+                echo "Dummy file exists on VM, migration successful."
+                break
+              else
+                echo "Dummy file does not exist on VM, migration failed."
+                exit 1
+              fi
+            fi
+            if (( i == MAX_ITER )); then
+              echo "Timeout waiting for VM to respond to SSH."
+              cat /var/log/VM.log
+              exit 1
+            fi
+            echo "Waiting for VM to respond to SSH... ($i/$MAX_ITER)"
+            sleep 10
+          done

--- a/.github/actions/test/integration/test/vm.xml
+++ b/.github/actions/test/integration/test/vm.xml
@@ -1,7 +1,7 @@
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
-    <name>HV_NAME_GOES_HERE</name>
-    <memory unit='GiB'>6</memory>
-    <vcpu>4</vcpu>
+    <name>VM</name>
+    <memory unit='GiB'>2</memory>
+    <vcpu>2</vcpu>
     <os firmware='efi'>
         <type arch='x86_64'>hvm</type>
         <loader readonly='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE_4M.fd</loader>
@@ -14,11 +14,17 @@
     <devices>
         <disk type='file' device='disk'>
             <driver name='qemu' type='qcow2' />
-            <source file='/var/lib/libvirt/images/HV_NAME_GOES_HERE.qcow2' />
+            <source file='/var/lib/libvirt/images/ubuntu.qcow2' />
             <target dev='hda' bus='ide' />
         </disk>
+        <disk type='file' device='cdrom'>
+            <driver name='qemu' type='raw' />
+            <source file='/var/lib/libvirt/images/ubuntu-cloud-init-ds.iso' />
+            <target dev='hdb' bus='ide' />
+            <readonly />
+        </disk>
         <interface type='network'>
-            <mac address='MAC_GOES_HERE' />
+            <mac address='52:54:00:00:00:01' />
             <source network='default' />
             <model type='virtio' />
         </interface>
@@ -26,12 +32,8 @@
             <target type='serial' port='0' />
         </console>
         <serial type='file'>
-            <source path='/var/log/HV_NAME_GOES_HERE.log' />
+            <source path='/var/log/VM.log' />
             <target port='0' />
         </serial>
     </devices>
-    <qemu:commandline>
-        <qemu:arg value='-fw_cfg' />
-        <qemu:arg value='name=opt/com.coreos/config,file=/var/lib/libvirt/images/hv.ign' />
-    </qemu:commandline>
 </domain>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,5 @@ jobs:
           image_tag: 1919.0.0-metal-sci-usi-amd64-1919.0-16c70177-amd64
       - name: Setup
         uses: ./.github/actions/test/integration/setup
+      - name: Test
+        uses: ./.github/actions/test/integration/test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test hypervisor capabilities
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Dependencies
+        uses: ./.github/actions/test/integration/dependencies
+      - name: Build
+        uses: ./.github/actions/test/integration/build
+        with:
+          image_tag: 1919.0.0-metal-sci-usi-amd64-1919.0-16c70177-amd64

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,19 @@
 name: test hypervisor capabilities
 on:
   push:
+    branches:
+      - ci-test-virtualization
+  workflow_run:
+    workflows:
+      - nightly
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to test (must be usi-sci)"
+        type: string
+        default: ""
 
 jobs:
   test:
@@ -10,10 +23,17 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Dependencies
         uses: ./.github/actions/test/integration/dependencies
+      - name: Obtain newest Tag from GHCR
+        id: fetch_tag
+        if: ${{ inputs.image_tag == '' || github.event_name == 'workflow_run' || github.event_name == 'push' }}
+        run: |
+          latest_tag=$(oras repo tags ghcr.io/gardenlinux/gardenlinux-ccloud | grep 'sci_usi' | sort -r | head -n 1)
+          echo $latest_tag
+          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
       - name: Build
         uses: ./.github/actions/test/integration/build
         with:
-          image_tag: 1919.0.0-metal-sci-usi-amd64-1919.0-16c70177-amd64
+          image_tag: ${{ env.latest_tag || inputs.image_tag }}
       - name: Setup
         uses: ./.github/actions/test/integration/setup
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -14,3 +14,5 @@ jobs:
         uses: ./.github/actions/test/integration/build
         with:
           image_tag: 1919.0.0-metal-sci-usi-amd64-1919.0-16c70177-amd64
+      - name: Setup
+        uses: ./.github/actions/test/integration/setup


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces a GitHub Workflow to test the basic hypervisor capabilities of the USI SCI images. Right now, this consists of starting and migrating a "customer VM" between two virtual "hypervisors".

On a high level, the flow looks like this:
- (optionally) obtain the newest tag for a `sci_usi` flavor
- build a bootable virtual disk image using UKI and systemd-boot
- generate a minimal ignition to allow bootstrap and operation inside QEMU
- download a ubuntu "customer VM" and generate a cloud-init for testing
- spawn 2 virtual machines on the GitHub Action Runner with the built gardenlinux-ccloud image and a shared network bridge
- after successful ignition bootstrap, configure libvirt on the "HyperVisors"
- spawn the "customer VM" on the first "HyperVisor"
- after successful cloud-init, write dummy data to the "customer VM"
- live-migrate the "customer VM" to the second "HyperVisor"
- verify that the dummy data is present on the "customer VM" after migration

For the more visual people:
![KVM Testing Nested drawio (1)](https://github.com/user-attachments/assets/84885321-15c0-43b5-8f27-97e7660138ba)

**Note** that right now, this is not in the critical path of the images yet. This is to get some initial feelings about the stability and usefulness of the test(s). It runs _after_ the nightlies and does not prohibit them from pushing their artifacts to the registries. In future, it could be a desirable change to also run this verification for PullRequests and/or only publish the artifacts when the test(s) pass.