### PR TITLE
ci: Switch CHV Device Type from cdrom to disk

### DIFF
--- a/.github/actions/test/integration/test/cloudhypervisor/vm.xml
+++ b/.github/actions/test/integration/test/cloudhypervisor/vm.xml
@@ -13,7 +13,7 @@
             <source file='/var/lib/libvirt/images/ubuntu.raw' />
             <target dev='hda' bus='virtio' />
         </disk>
-        <disk type='file' device='cdrom'>
+        <disk type='file' device='disk'>
             <source file='/var/lib/libvirt/images/ubuntu-cloud-init-ds.iso' />
             <target dev='hdb' bus='virtio' />
             <readonly />


### PR DESCRIPTION
Somehow this only showed up in [1952](https://github.com/gardenlinux/gardenlinux-ccloud/actions/runs/16715708749/job/47319300317) for the first time:

```
 error: Failed to define domain from /opt/vm-chv.xml
error: unsupported configuration: disk type of 'hdb' does not support ejectable media
error: failed to get domain 'VM-CHV'
```

Works with `disk`, but not `cdrom`.