### PR TITLE
fix: dracut move of initrd failure

### DIFF
--- a/features/_pxe/image.pxe.tar.gz
+++ b/features/_pxe/image.pxe.tar.gz
@@ -27,7 +27,6 @@ echo "console=ttyS0 gl.live=1 gl.ovl=/:tmpfs" > cmdline
 touch tmp_initrd
 [[ ! -e "$chroot_dir/initrd" ]]
 touch "$chroot_dir/initrd"
-mount --bind tmp_initrd "$chroot_dir/initrd"
 [[ ! -e "$chroot_dir/root.squashfs" ]]
 touch "$chroot_dir/root.squashfs"
 mount --bind root.squashfs "$chroot_dir/root.squashfs"
@@ -50,8 +49,7 @@ chroot "$chroot_dir" env dracut \
 
 umount -l "$chroot_dir/proc"
 
-umount "$chroot_dir/initrd"
-rm "$chroot_dir/initrd"
+mv "$chroot_dir/initrd" tmp_initrd
 umount "$chroot_dir/root.squashfs"
 rm "$chroot_dir/root.squashfs"
 

--- a/features/_usi/image.cc.tar
+++ b/features/_usi/image.cc.tar
@@ -52,8 +52,6 @@ mount --bind "$erofs" "$rootfs/tmp/initrd.include/root.img"
 initrd="$(mktemp)"
 
 touch "$rootfs/initrd"
-mount --bind "$initrd" "$rootfs/initrd"
-
 kernel="$(find "$rootfs/boot/" -name 'vmlinuz-*' | sort -V | tail -n 1)"
 
 chroot "$rootfs" dracut \
@@ -74,7 +72,7 @@ umount -l "$rootfs/proc"
 umount -R "$rootfs/dev"
 umount "$rootfs/tmp"
 
-umount "$rootfs/initrd"
+mv "$rootfs/initrd" "$initrd"
 
 case "$BUILDER_ARCH" in
 	amd64)


### PR DESCRIPTION
dracut-ng introduced `protection of existing files again output errors`, making it incompatible with bind mounts (commit: 39a765d). see also https://github.com/gardenlinux/gardenlinux/pull/3291.