### PR TITLE
Remove 2nd version number from additional OCI tag

### DIFF
--- a/.github/workflows/upload_oci.yml
+++ b/.github/workflows/upload_oci.yml
@@ -69,7 +69,10 @@ jobs:
       - name: Add additional semver tag
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | oras login -u ${{ github.repository_owner }} --password-stdin ghcr.io
-          oras tag ghcr.io/${{ github.repository }}:${{ inputs.version }}-${CNAME}-${{ matrix.arch }} ${{ inputs.version }}-${CNAME//_/-}-${{ matrix.arch }}
+          CNAME2=${CNAME//_/-}
+          CNAME2=${CNAME2//-${{ inputs.version }}/}
+          echo "Adding additional tag: ${{ inputs.version }}-${CNAME2}-${{ matrix.arch }}"
+          oras tag ghcr.io/${{ github.repository }}:${{ inputs.version }}-${CNAME}-${{ matrix.arch }} ${{ inputs.version }}-${CNAME2}-${{ matrix.arch }}
       - uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # pin@v4.2.3
         with:
           path: oci_manifest_entry_${{ env.CNAME }}.json

--- a/features/_usi/initrd.include/usr/bin/persist
+++ b/features/_usi/initrd.include/usr/bin/persist
@@ -75,7 +75,7 @@ OCI_ARCH="${OCI_ARCH:-amd64}"
 export HOME=/root
 
 # setup OCI_TAG, UKI_SHA and fetch UKI
-OCI_TAG="$GARDENLINUX_VERSION-$GARDENLINUX_CNAME-$GARDENLINUX_COMMIT_ID-$OCI_ARCH"
+OCI_TAG="$GARDENLINUX_VERSION-$VARIANT_ID-$GARDENLINUX_COMMIT_ID-$OCI_ARCH"
 OCI_TAG=${OCI_TAG//_/-} # replace underscores with dashes
 UKI_SHA=$(oras manifest fetch "$OCI_REPO:${OCI_TAG}" | jq -r '.layers[] | select(.mediaType=="application/io.gardenlinux.uki") | .digest')
 oras blob fetch "$OCI_REPO@$UKI_SHA" -o "$esp_dir/EFI/Linux/uki.efi"


### PR DESCRIPTION
This will update the 2nd tag from
`2036.0.0-metal-capi-amd64-2036.0.0-d1baca65-amd64` to `2036.0.0-metal-capi-amd64-d1baca65-amd64`
