### PR TITLE
Use an addon for the hugepages kernel cmdline

### DIFF
--- a/features/_usi/image.cc.tar
+++ b/features/_usi/image.cc.tar
@@ -58,7 +58,7 @@ chroot "$rootfs" dracut \
 	--kver "${kernel#*-}" \
 	--modules "bash dash systemd systemd-emergency systemd-initrd systemd-repart systemd-resolved systemd-cryptsetup kernel-modules kernel-modules-extra terminfo udev-rules dracut-systemd base fs-lib shutdown crypt" \
 	--reproducible \
-	--install 'find findmnt grep lsblk tail head realpath basename sfdisk mkfs.ext4 mkfs.vfat wget oras efibootmgr objcopy resizefat32 dd cryptsetup' \
+	--install 'find findmnt grep lsblk tail head realpath basename sfdisk mkfs.ext4 mkfs.vfat wget oras efibootmgr objcopy objdump resizefat32 dd cryptsetup' \
 	--include '/tmp/initrd.include' / \
 	--add-drivers erofs \
 	/initrd
@@ -81,7 +81,7 @@ chroot "$rootfs" ukify build \
 	--linux "/boot/$kernel" \
 	--initrd "/initrd" \
 	--uname "${kernel#*-}" \
-	--cmdline "$cmdline xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+	--cmdline "$cmdline" \
 	--os-release "@/etc/os-release" \
 	--output "/uki"
 

--- a/features/_usi/initrd.include/usr/bin/persist
+++ b/features/_usi/initrd.include/usr/bin/persist
@@ -81,12 +81,17 @@ UKI_SHA=$(oras manifest fetch "$OCI_REPO:${OCI_TAG}" | jq -r '.layers[] | select
 oras blob fetch "$OCI_REPO@$UKI_SHA" -o "$esp_dir/EFI/Linux/uki.efi"
 
 if [ "$ENABLE_HUGEPAGE_SETUP" = "true" ]; then
-  # update the kernel cmdline in the uki
-  # TODO: when using the USI tool to perform the in place update, should the cmdline of the new image also be changed?
-  # n.b. secureboot makes all this impossible!
-  cmdline=$(objcopy --dump-section .cmdline=/dev/stdout /sysroot/efi/EFI/Linux/uki.efi | sed -r 's/x{8,}//')
-  echo "$cmdline hugepagesz=2MB hugepages=$hugepages" > /tmp/cmdlinef
-  objcopy --update-section .cmdline=/tmp/cmdlinef /sysroot/efi/EFI/Linux/uki.efi
+  echo "hugepagesz=2MB hugepages=$hugepages" > /tmp/cmdlinef
+  addon="/sysroot/usr/lib/systemd/boot/efi/addonx64.efi.stub"
+  offs=$(objdump -h $addon | awk 'NF==7 {size=$3;offset=$4} END {print "16#"size" + 16#"offset}')
+  if [[ $offs -eq 0 ]]; then
+    echo "the offset can't be calculated for the stub addon"
+    exit 1
+  fi
+  align=$(objdump -p $addon | grep Section | awk '{ print "16#"$2}')
+  offs=$((offs + "$align" - offs % "$align"))
+  mkdir -p /sysroot/efi/EFI/loader/addons
+  objcopy --add-section .cmdline=/tmp/cmdlinef --change-section-vma .cmdline=$(printf 0x%x $offs) $addon /sysroot/efi/EFI/loader/addons/hugepages.addon.efi
 fi
 
 # Network config generation


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we use a rather dirty way of modifying the kernel cmdline in order to change it and add the hugepage settings.
This PR switches this mechanism to using a systemd-stub addon for appending to the cmdline baked into the UKI.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

