### PR TITLE
feat(rescue): debugprint journal logs of failing units immediately

### DIFF
--- a/features/_rescue/file.include/etc/dracut.conf.d/30-dracut-emergency.conf
+++ b/features/_rescue/file.include/etc/dracut.conf.d/30-dracut-emergency.conf
@@ -1,2 +1,3 @@
 add_dracutmodules+=" systemd-emergency "
-install_items+=" /etc/systemd/system/emergency.service.d/sulogin.conf " 
+install_items+=" /etc/systemd/system/emergency.service.d/sulogin.conf "
+install_items+=" /etc/systemd/system/emergency.service.d/debugprint.conf "

--- a/features/_rescue/file.include/etc/systemd/system/emergency.service.d/debugprint.conf
+++ b/features/_rescue/file.include/etc/systemd/system/emergency.service.d/debugprint.conf
@@ -1,0 +1,10 @@
+[Service]
+StandardOutput=journal+console
+StandardError=journal+console
+ExecStartPre=/bin/sh -c ' \
+  systemctl --failed --no-legend --no-pager | awk "{print \$2}" | \
+  xargs -r -I{} sh -c " \
+    echo \"\\n=== FAILED UNIT: {} ===\\n\"; \
+    journalctl -b -u {} --no-pager || true; \
+  "'
+TimeoutStartSec=20s


### PR DESCRIPTION
Analysing failures like [this](https://github.com/gardenlinux/gardenlinux-ccloud/actions/runs/19288551119/job/55154108886) is impossible post-mortem if the logs are not output as a precaution. Add a small unit to print all failing units and their logs in case rescue mode is entered.