### PR TITLE
Bump packages libvirt and cloud hypervisor

### DIFF
--- a/features/sci/exec.config
+++ b/features/sci/exec.config
@@ -9,8 +9,8 @@ systemctl enable ssh
 
 # all versions URL encoded
 EDK2_VERSION="20260221-0gl1%2Bbp1877"
-LIBVIRT_VERSION="12.1.0-1gl5%2Bbp1877"
-CLOUD_HYPERVISOR_VERSION="51.1-1gl6%2Bbp1877"
+LIBVIRT_VERSION="12.1.0-1gl6%2Bbp1877"
+CLOUD_HYPERVISOR_VERSION="51.1-1gl7%2Bbp1877"
 
 mkdir /tmp/custompackages
 for p in https://github.com/gardenlinux/package-edk2-cloud-hypervisor-gl/releases/download/$EDK2_VERSION/build.tar.xz.0000 https://github.com/gardenlinux/package-libvirt/releases/download/$LIBVIRT_VERSION/build.tar.xz.0000 https://github.com/gardenlinux/package-cloud-hypervisor-gl/releases/download/$CLOUD_HYPERVISOR_VERSION/build.tar.xz.0000; do


### PR DESCRIPTION
```diff
-LIBVIRT_VERSION="12.1.0-1gl5%2Bbp1877"
-CLOUD_HYPERVISOR_VERSION="51.1-1gl6%2Bbp1877"
+LIBVIRT_VERSION="12.1.0-1gl6%2Bbp1877"
+CLOUD_HYPERVISOR_VERSION="51.1-1gl7%2Bbp1877"
```
