### PR TITLE
Add ignition from package repo

### DIFF
--- a/.github/actions/test/integration/build/dev-user-butane.yaml
+++ b/.github/actions/test/integration/build/dev-user-butane.yaml
@@ -1,5 +1,5 @@
 variant: fcos
-version: 1.3.0
+version: 1.7.0
 passwd:
   users:
     - name: root

--- a/.github/actions/test/integration/dependencies/action.yml
+++ b/.github/actions/test/integration/dependencies/action.yml
@@ -34,7 +34,7 @@ runs:
     - name: butane
       shell: bash
       run: |
-        BUTANE_VERSION="0.24.0"
+        BUTANE_VERSION="0.27.0"
         curl -LO "https://github.com/coreos/butane/releases/download/v${BUTANE_VERSION}/butane-x86_64-unknown-linux-gnu"
         chmod +x "butane-x86_64-unknown-linux-gnu"
         sudo mv "butane-x86_64-unknown-linux-gnu" /usr/local/bin/butane

--- a/features/_usi/exec.config
+++ b/features/_usi/exec.config
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -eufo pipefail
+set -euo pipefail
 
 #TODO: oras should be pulled in via pkg.include, but we don't have it for 1877, will be in the next release
 pushd /tmp
@@ -19,3 +19,17 @@ mkdir -p /efi
 [ -e /usr/lib/systemd/systemd-pcrphase ] || ln -s systemd-pcrextend /usr/lib/systemd/systemd-pcrphase
 
 mkdir -p /var/etc.overlay /var/etc.overlay.workdir
+
+# temporary adding latest ignition until it is in the repo
+IGNITION_VERSION="2.26.0-0gl0%2Bbp1877"
+TEMP_DIR=$(mktemp -d)
+for p in "https://github.com/gardenlinux/package-ignition/releases/download/$IGNITION_VERSION/build.tar.xz.0000"; do
+  echo "Downloading and extracting package from $p"
+  wget -q "$p" -O - | xz -d | tar xf - -C "$TEMP_DIR"
+  ls "$TEMP_DIR"
+done
+
+pushd "$TEMP_DIR" > /dev/null
+dpkg -i ignition_*_amd64.deb
+popd > /dev/null
+rm -rf "$TEMP_DIR"

--- a/features/_usi/pkg.exclude
+++ b/features/_usi/pkg.exclude
@@ -1,0 +1,1 @@
+ignition


### PR DESCRIPTION
Until the upstream repo is updated we add the latest ignition package
from the github releases.
