### PR TITLE
sci: Set nfs max_session_slots=512

### DIFF
--- a/features/sci/file.include/etc/modprobe.d/nfsclient.conf
+++ b/features/sci/file.include/etc/modprobe.d/nfsclient.conf
@@ -1,0 +1,3 @@
+# According to Netapp KVM Best Practices mount options this value should be nconnect*64 (nconnect=8)
+options nfs max_session_slots=512
+


### PR DESCRIPTION
Netapp recommends nconnect=8 and setting the value
to 64 times nconnect, so we end up with 512.
