### PR TITLE
chore: add renovate.json to rel-2150-dev

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+}


### PR DESCRIPTION
## Summary

Adds a minimal `renovate.json` to the `rel-2150-dev` base branch so Renovate can fetch it when processing this branch with `useBaseBranchConfig: merge`.

## Context

Without this file, Renovate fails with:
```
Error fetching config file `renovate.json` from branch `rel-2150-dev`
```

The file contains only the schema reference — no overrides — so the branch fully inherits the config from the default branch via the merge strategy.

Unblocks: #238