### PR TITLE
renovate: automate SCI package updates for rel-1877-dev

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,54 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update libvirt package version for rel-1877-dev",
+      "managerFilePatterns": ["/features/sci/exec\\.config$/"],
+      "matchStrings": [
+        "LIBVIRT_VERSION=\"(?<currentValue>[^%]+)%2Bbp1877\""
+      ],
+      "depNameTemplate": "gardenlinux/package-libvirt",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>.+)\\+bp1877$",
+      "versioningTemplate": "loose",
+      "autoReplaceStringTemplate": "LIBVIRT_VERSION=\"{{{newValue}}}%2Bbp1877\""
+    },
+    {
+      "customType": "regex",
+      "description": "Update cloud-hypervisor-gl package version for rel-1877-dev",
+      "managerFilePatterns": ["/features/sci/exec\\.config$/"],
+      "matchStrings": [
+        "CLOUD_HYPERVISOR_VERSION=\"(?<currentValue>[^%]+)%2Bbp1877\""
+      ],
+      "depNameTemplate": "gardenlinux/package-cloud-hypervisor-gl",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>.+)\\+bp1877$",
+      "versioningTemplate": "loose",
+      "autoReplaceStringTemplate": "CLOUD_HYPERVISOR_VERSION=\"{{{newValue}}}%2Bbp1877\""
+    },
+    {
+      "customType": "regex",
+      "description": "Update edk2-cloud-hypervisor-gl package version for rel-1877-dev",
+      "managerFilePatterns": ["/features/sci/exec\\.config$/"],
+      "matchStrings": [
+        "EDK2_VERSION=\"(?<currentValue>[^%]+)%2Bbp1877\""
+      ],
+      "depNameTemplate": "gardenlinux/package-edk2-cloud-hypervisor-gl",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^(?<version>.+)\\+bp1877$",
+      "versioningTemplate": "loose",
+      "autoReplaceStringTemplate": "EDK2_VERSION=\"{{{newValue}}}%2Bbp1877\""
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "gardenlinux/package-libvirt",
+        "gardenlinux/package-cloud-hypervisor-gl",
+        "gardenlinux/package-edk2-cloud-hypervisor-gl"
+      ],
+      "groupName": "SCI custom packages"
+    }
+  ]
 }


### PR DESCRIPTION
Add custom regex managers for `libvirt`, `cloud-hypervisor-gl`, and `edk2-cloud-hypervisor-gl` packages. These packages are hosted in gardenlinux org repos and use branch-specific release tags with a `+bp1877` suffix.

The managers:
- Extract the version prefix (before the %2B-encoded '+') as the current value for comparison against GitHub release tags
- Filter datasource releases to only those ending in `+bp1877` via `extractVersionTemplate`, excluding staging (`+sta`) and cross-branch (`+bp2150`) releases
- Write back with the correct URL-encoded suffix via `autoReplaceStringTemplate`
- Group all three packages into a single PR via `packageRules` (`groupName: "SCI custom packages"`)