### PR TITLE
Enable Renovate tracking for upstream gardenlinux

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
     "/^rel-\\d+-dev$/"
   ],
   "useBaseBranchConfig": "merge",
+  "git-submodules": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchPackageNames": [
@@ -16,6 +19,18 @@
         "gardenlinux/package-edk2-cloud-hypervisor-gl"
       ],
       "groupName": "SCI custom packages",
+      "separateMajorMinor": false
+    },
+    {
+      "matchManagers": [
+        "git-submodules",
+        "custom.regex"
+      ],
+      "matchDepNames": [
+        "gardenlinux/gardenlinux",
+        "gardenlinux"
+      ],
+      "groupName": "gardenlinux upstream",
       "separateMajorMinor": false
     }
   ]


### PR DESCRIPTION
Enables the git-submodules manager and groups submodule + workflow `uses:` updates for `gardenlinux/gardenlinux` into one PR. Per-rel branch targeting is set on each `rel-XXXX-dev` branch.