### PR TITLE
Track upstream gardenlinux/rel-2150 via Renovate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "gardenlinux"]
 	path = gardenlinux
 	url = https://github.com/gardenlinux/gardenlinux
+	branch = rel-2150

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,25 @@
       "extractVersionTemplate": "^(?<version>.+)\\+bp2150$",
       "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "EDK2_VERSION=\"{{{newValue}}}%2Bbp2150\""
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "uses:\\s*gardenlinux/gardenlinux/\\.github/workflows/[^@\\s]+@(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "depNameTemplate": "gardenlinux/gardenlinux",
+      "packageNameTemplate": "https://github.com/gardenlinux/gardenlinux",
+      "datasourceTemplate": "git-refs",
+      "currentValueTemplate": "rel-2150"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["git-refs"],
+      "matchDepNames": ["gardenlinux/gardenlinux", "gardenlinux"],
+      "versioning": "loose",
+      "allowedVersions": "/^rel-2150$/"
     }
   ]
 }


### PR DESCRIPTION
Adds an overlay customManager that bumps the pinned `uses:` SHAs in `.github/workflows/*.yml` to upstream `rel-2150` HEAD, and sets `branch = rel-2150` in `.gitmodules` so the git-submodules manager tracks the same release line.
