### PR TITLE
Track upstream gardenlinux/rel-1877 via Renovate

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "gardenlinux"]
 	path = gardenlinux
 	url = https://github.com/gardenlinux/gardenlinux
+	branch = rel-1877

--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,25 @@
       "extractVersionTemplate": "^(?<version>.+)\\+bp1877$",
       "versioningTemplate": "loose",
       "autoReplaceStringTemplate": "EDK2_VERSION=\"{{{newValue}}}%2Bbp1877\""
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^\\.github/workflows/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "uses:\\s*gardenlinux/gardenlinux/\\.github/workflows/[^@\\s]+@(?<currentDigest>[a-f0-9]{40})"
+      ],
+      "depNameTemplate": "gardenlinux/gardenlinux",
+      "packageNameTemplate": "https://github.com/gardenlinux/gardenlinux",
+      "datasourceTemplate": "git-refs",
+      "currentValueTemplate": "rel-1877"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["git-refs"],
+      "matchDepNames": ["gardenlinux/gardenlinux", "gardenlinux"],
+      "versioning": "loose",
+      "allowedVersions": "/^rel-1877$/"
     }
   ]
 }


### PR DESCRIPTION
Adds an overlay customManager that bumps the pinned `uses:` SHAs in `.github/workflows/*.yml` to upstream `rel-1877` HEAD, and sets `branch = rel-1877` in `.gitmodules` so the git-submodules manager tracks the same release line.