### PR TITLE
Apply systemd presets

### DIFF
--- a/features/sci/exec.config
+++ b/features/sci/exec.config
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# Apply systemd presets
+systemctl preset-all
+
 # Undo the gardener feature disablement
 systemctl enable ssh
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Some systemd presets are being installed in the image but they are not enabled. Fix that by calling `systemd preset-all`. On a running system this produces the following output.

```
Removed '/etc/systemd/system/ipmi.service'.
Removed '/etc/systemd/system/multi-user.target.wants/ipmievd.service'.
Removed '/etc/systemd/system/multi-user.target.wants/ssh.service'.
Removed '/etc/systemd/system/multi-user.target.wants/containerd.service'.
Removed '/etc/systemd/system/sshd.service'.
Removed '/etc/systemd/system/timers.target.wants/apt-daily.timer'.
Removed '/etc/systemd/system/timers.target.wants/dpkg-db-backup.timer'.
Unit /etc/systemd/system/systemd-repart.service is masked, ignoring.
Unit /etc/systemd/system/libvirtd-tcp.socket is masked, ignoring.
Created symlink '/etc/systemd/system/multi-user.target.wants/gardener-node-init.service' → '/etc/systemd/system/gardener-node-init.service'.
Unit /usr/lib/systemd/system/cryptdisks-early.service is masked, ignoring.
Unit /usr/lib/systemd/system/cryptdisks.service is masked, ignoring.
Unit /usr/lib/systemd/system/hwclock.service is masked, ignoring.
Unit /usr/lib/systemd/system/nfs-common.service is masked, ignoring.
Unit /usr/lib/systemd/system/sshd-keygen.service is added as a dependency to a non-existent unit sshd.service.
Unit /usr/lib/systemd/system/sshguard.service is added as a dependency to a non-existent unit nftables.service.
Unit /usr/lib/systemd/system/sudo.service is masked, ignoring.
Unit /usr/lib/systemd/system/system-xfs_scrub.slice is added as a dependency to a non-existent unit system.slice.
Unit /usr/lib/systemd/system/x11-common.service is masked, ignoring.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
NONE

**Release note**:
NONE
