### PR TITLE
fix(ci): try to improve performance

### DIFF
--- a/.github/actions/test/integration/setup/hv.xml
+++ b/.github/actions/test/integration/setup/hv.xml
@@ -15,7 +15,7 @@
         <disk type='file' device='disk'>
             <driver name='qemu' type='qcow2' />
             <source file='/var/lib/libvirt/images/HV_NAME_GOES_HERE.qcow2' />
-            <target dev='hda' bus='ide' />
+            <target dev='vda' bus='virtio' />
         </disk>
         <interface type='network'>
             <mac address='MAC_GOES_HERE' />

--- a/.github/actions/test/integration/test/qemu/vm.xml
+++ b/.github/actions/test/integration/test/qemu/vm.xml
@@ -15,12 +15,12 @@
         <disk type='file' device='disk'>
             <driver name='qemu' type='qcow2' />
             <source file='/var/lib/libvirt/images/ubuntu.qcow2' />
-            <target dev='hda' bus='ide' />
+            <target dev='vda' bus='virtio' />
         </disk>
-        <disk type='file' device='cdrom'>
+        <disk type='file' device='disk'>
             <driver name='qemu' type='raw' />
             <source file='/var/lib/libvirt/images/ubuntu-cloud-init-ds.iso' />
-            <target dev='hdb' bus='ide' />
+            <target dev='vdb' bus='virtio' />
             <readonly />
         </disk>
         <interface type='network'>


### PR DESCRIPTION
we are seeing a lot of 
> workqueue: ata_sff_pio_task hogged CPU for >10000us 4 times

in timed-out tests which comes from the IDE Driver. Try if switching to `virtio-blk` speeds things up.