### PR TITLE
Add modified gardenlinux-update tool for in-place update testing

### DIFF
--- a/features/_usidev/exec.config
+++ b/features/_usidev/exec.config
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
-set -eufo pipefail
+set -euo pipefail
 
 mkdir -p /var/usr.overlay /var/usr.overlay.workdir
+
+# install
+mkdir /tmp/custompackages
+package="https://github.com/toanju/package-gardenlinux-update/releases/download/0.9gl4%2Bbp1877/build.tar.xz.0000"
+
+echo "Downloading and extracting package from $package"
+wget -q "$package" -O - | xz -d | tar xf - -C /tmp/custompackages
+
+pushd /tmp/custompackages > /dev/null
+rm -f -- *dbgsym* *arm64* || true
+ls -1
+dpkg -i gardenlinux-update_*_amd64.deb
+popd > /dev/null
+rm -rf /tmp/custompackages

--- a/features/_usidev/pkg.exclude
+++ b/features/_usidev/pkg.exclude
@@ -1,0 +1,1 @@
+gardenlinux-update


### PR DESCRIPTION
The modified tool is currently build in
https://github.com/toanju/package-gardenlinux-update and disables OCI
image verification by default. This is required to speed up testing the
Gardener in-place update before implementing all details. Hence this
only goes to the dev image.

Signed-off-by: Tobias Jungel <1773291+toanju@users.noreply.github.com>
