### PR TITLE
Use not encoded version strings

### DIFF
--- a/features/sci/exec.config
+++ b/features/sci/exec.config
@@ -12,9 +12,9 @@ systemctl enable ssh
 # TODO : these all should go in the repo
 
 # all versions URL encoded
-EDK2_VERSION="20260221-0gl1%2Bbp1877"
-LIBVIRT_VERSION="12.2.0-1gl5%2Bbp1877"
-CLOUD_HYPERVISOR_VERSION="52.1-1gl4%2Bbp1877"
+EDK2_VERSION="20260221-0gl1+bp1877"
+LIBVIRT_VERSION="12.2.0-1gl5+bp1877"
+CLOUD_HYPERVISOR_VERSION="52.1-1gl4+bp1877"
 
 mkdir /tmp/custompackages
 for p in https://github.com/gardenlinux/package-edk2-cloud-hypervisor-gl/releases/download/$EDK2_VERSION/build.tar.xz.0000 https://github.com/gardenlinux/package-libvirt/releases/download/$LIBVIRT_VERSION/build.tar.xz.0000 https://github.com/gardenlinux/package-cloud-hypervisor-gl/releases/download/$CLOUD_HYPERVISOR_VERSION/build.tar.xz.0000; do

--- a/renovate.json
+++ b/renovate.json
@@ -6,39 +6,39 @@
       "description": "Update libvirt package version for rel-1877-dev",
       "managerFilePatterns": ["/features/sci/exec\\.config$/"],
       "matchStrings": [
-        "LIBVIRT_VERSION=\"(?<currentValue>[^%]+)%2Bbp1877\""
+        "LIBVIRT_VERSION=\"(?<currentValue>.+)\\+bp1877\""
       ],
       "depNameTemplate": "gardenlinux/package-libvirt",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^(?<version>.+)\\+bp1877$",
       "versioningTemplate": "loose",
-      "autoReplaceStringTemplate": "LIBVIRT_VERSION=\"{{{newValue}}}%2Bbp1877\""
+      "autoReplaceStringTemplate": "LIBVIRT_VERSION=\"{{{newValue}}}+bp1877\""
     },
     {
       "customType": "regex",
       "description": "Update cloud-hypervisor-gl package version for rel-1877-dev",
       "managerFilePatterns": ["/features/sci/exec\\.config$/"],
       "matchStrings": [
-        "CLOUD_HYPERVISOR_VERSION=\"(?<currentValue>[^%]+)%2Bbp1877\""
+        "CLOUD_HYPERVISOR_VERSION=\"(?<currentValue>.+)\\+bp1877\""
       ],
       "depNameTemplate": "gardenlinux/package-cloud-hypervisor-gl",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^(?<version>.+)\\+bp1877$",
       "versioningTemplate": "loose",
-      "autoReplaceStringTemplate": "CLOUD_HYPERVISOR_VERSION=\"{{{newValue}}}%2Bbp1877\""
+      "autoReplaceStringTemplate": "CLOUD_HYPERVISOR_VERSION=\"{{{newValue}}}+bp1877\""
     },
     {
       "customType": "regex",
       "description": "Update edk2-cloud-hypervisor-gl package version for rel-1877-dev",
       "managerFilePatterns": ["/features/sci/exec\\.config$/"],
       "matchStrings": [
-        "EDK2_VERSION=\"(?<currentValue>[^%]+)%2Bbp1877\""
+        "EDK2_VERSION=\"(?<currentValue>.+)\\+bp1877\""
       ],
       "depNameTemplate": "gardenlinux/package-edk2-cloud-hypervisor-gl",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^(?<version>.+)\\+bp1877$",
       "versioningTemplate": "loose",
-      "autoReplaceStringTemplate": "EDK2_VERSION=\"{{{newValue}}}%2Bbp1877\""
+      "autoReplaceStringTemplate": "EDK2_VERSION=\"{{{newValue}}}+bp1877\""
     }
   ]
 }


### PR DESCRIPTION
Use not encoded values for better readability and improve update
handling. In addition, future tags will included 2 + signs which now is
handled.

Signed-off-by: Tobias Jungel <1773291+toanju@users.noreply.github.com>
